### PR TITLE
Fix handling of illegal JSON characters during (de)serialization

### DIFF
--- a/app-kmm-journal3/build.gradle.kts
+++ b/app-kmm-journal3/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
                 api(Dependencies.Commons.DATETIME)
                 api(Dependencies.Commons.OKIO)
 
-                implementation(Dependencies.Commons.JSON)
+                implementation(Dependencies.Commons.KOTLINX_JSON_OKIO)
             }
         }
         val commonTest by getting {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFile.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFile.kt
@@ -20,6 +20,7 @@ package com.hadisatrio.apps.kotlin.journal3.json
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonObject
 import okio.FileSystem
 import okio.Path
@@ -43,7 +44,7 @@ class JsonFile(
     }
 
     fun getRaw(key: String): String? {
-        return jsonObject()[key]?.toString()?.removeSurrounding("\"")
+        return (get(key) as? JsonPrimitive)?.content
     }
 
     fun delete() {

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFileTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFileTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.json
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.JsonPrimitive
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.fakefilesystem.FakeFileSystem
+import kotlin.test.AfterTest
+import kotlin.test.Test
+
+class JsonFileTest {
+
+    private val fileSystem = FakeFileSystem()
+    private val path = "foo.json".toPath()
+
+    @AfterTest
+    fun `Closes all file streams`() {
+        fileSystem.checkNoOpenFiles()
+    }
+
+    @Test
+    fun `Writes elements to the file`() {
+        val jsonFile = JsonFile(fileSystem, path)
+        jsonFile.put("Fizz", JsonPrimitive("Buzz"))
+
+        val fileContent = fileSystem.source(path).buffer().use { it.readUtf8() }
+        fileContent.shouldBe("""{"Fizz":"Buzz"}""")
+    }
+
+    @Test
+    fun `Guards against illegal JSON characters during writes`() = shouldNotThrow<Exception> {
+        val jsonFile = JsonFile(fileSystem, path)
+        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" """))
+
+        val fileContent = fileSystem.source(path).buffer().use { it.readUtf8() }
+        fileContent.shouldBe("""{"Fizz":" Buzz\" "}""")
+    }
+
+    @Test
+    fun `Guards against illegal JSON characters during reads`() = shouldNotThrow<Exception> {
+        val jsonFile = JsonFile(fileSystem, path)
+        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" """))
+
+        jsonFile.get("Fizz").shouldBe(JsonPrimitive(""" Buzz" """))
+        jsonFile.getRaw("Fizz").shouldBe(""" Buzz" """)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFileTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/json/JsonFileTest.kt
@@ -48,18 +48,18 @@ class JsonFileTest {
     @Test
     fun `Guards against illegal JSON characters during writes`() = shouldNotThrow<Exception> {
         val jsonFile = JsonFile(fileSystem, path)
-        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" """))
+        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" 👩‍👩‍👧 """))
 
         val fileContent = fileSystem.source(path).buffer().use { it.readUtf8() }
-        fileContent.shouldBe("""{"Fizz":" Buzz\" "}""")
+        fileContent.shouldBe("""{"Fizz":" Buzz\" 👩‍👩‍👧 "}""")
     }
 
     @Test
     fun `Guards against illegal JSON characters during reads`() = shouldNotThrow<Exception> {
         val jsonFile = JsonFile(fileSystem, path)
-        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" """))
+        jsonFile.put("Fizz", JsonPrimitive(""" Buzz" 👩‍👩‍👧 """))
 
-        jsonFile.get("Fizz").shouldBe(JsonPrimitive(""" Buzz" """))
-        jsonFile.getRaw("Fizz").shouldBe(""" Buzz" """)
+        jsonFile.get("Fizz").shouldBe(JsonPrimitive(""" Buzz" 👩‍👩‍👧 """))
+        jsonFile.getRaw("Fizz").shouldBe(""" Buzz" 👩‍👩‍👧 """)
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -29,7 +29,7 @@ object Dependencies {
     object Commons {
         const val UUID = "com.benasher44:uuid:0.4.0"
         const val DATETIME = "org.jetbrains.kotlinx:kotlinx-datetime:0.4.0"
-        const val JSON = "org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.0"
+        const val KOTLINX_JSON_OKIO = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio:1.4.0"
         const val OKIO = "com.squareup.okio:okio:3.2.0"
     }
 


### PR DESCRIPTION
### What has changed
We're now depending on `JsonPrimitive#content` to obtain raw string values within `JsonFile`.

### Why was it changed
`JsonElement#toString()` will attempt to surround `content` with `"`, which we don't want. Simply removing those surrounding quotes manually is error-prone.