### PR TITLE
Remind users to write after a certain duration

### DIFF
--- a/app-android-journal3/build.gradle.kts
+++ b/app-android-journal3/build.gradle.kts
@@ -15,6 +15,8 @@ plugins {
 
 dependencies {
     implementation(project(":app-kmm-journal3"))
+    implementation(Dependencies.AndroidArchitecture.STARTUP)
+    implementation(Dependencies.AndroidAsynchrony.WORKMANAGER)
 }
 
 detekt {

--- a/app-android-journal3/src/main/AndroidManifest.xml
+++ b/app-android-journal3/src/main/AndroidManifest.xml
@@ -33,6 +33,17 @@
         android:theme="@style/Theme.Journal3"
         tools:targetApi="31">
 
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data  android:name="com.hadisatrio.apps.android.journal3.notification.NotificationChannelInitializer"
+                android:value="androidx.startup" />
+            <meta-data  android:name="com.hadisatrio.apps.android.journal3.alert.InactivityAlertingWorkInitializer"
+                android:value="androidx.startup" />
+        </provider>
+
         <activity
             android:name=".story.ViewStoriesActivity"
             android:exported="true">

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3.kt
@@ -32,6 +32,7 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.datetime.Clock
 import okio.FileSystem
 import okio.Path.Companion.toPath
 import kotlin.time.Duration
@@ -69,6 +70,10 @@ class Journal3 : Application() {
 
     val inactivityAlertThreshold: Duration by lazy {
         3.hours
+    }
+
+    val clock: Clock by lazy {
+        Clock.System
     }
 
     companion object {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3.kt
@@ -34,6 +34,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import okio.FileSystem
 import okio.Path.Companion.toPath
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
 
 class Journal3 : Application() {
 
@@ -63,6 +65,10 @@ class Journal3 : Application() {
 
     val globalEventSource: EventHub by lazy {
         EventHub(MutableSharedFlow(extraBufferCapacity = 1))
+    }
+
+    val inactivityAlertThreshold: Duration by lazy {
+        3.hours
     }
 
     companion object {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertModalNotificationBuilderAdapter.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertModalNotificationBuilderAdapter.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.alert
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import com.hadisatrio.apps.android.journal3.R
+import com.hadisatrio.apps.android.journal3.notification.NotificationChannel
+import com.hadisatrio.apps.android.journal3.story.ViewStoriesActivity
+import com.hadisatrio.libs.android.foundation.modal.NotificationModalPresenter.NotificationBuilderFactory
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.presentation.Adapter
+
+class InactivityAlertModalNotificationBuilderAdapter(
+    private val context: Context,
+    private val channel: NotificationChannel
+) : Adapter<Modal, NotificationBuilderFactory> {
+
+    override fun adapt(thing: Modal): NotificationBuilderFactory {
+        require(thing.kind == "inactivity_alert") {
+            "Expected modal kind to be 'inactivity_alert'; was ${thing.kind}."
+        }
+
+        return object : NotificationBuilderFactory {
+            override fun create(): NotificationCompat.Builder {
+                return NotificationCompat.Builder(context, channel.id).apply {
+                    val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                    } else {
+                        PendingIntent.FLAG_UPDATE_CURRENT
+                    }
+                    val pendingIntent = PendingIntent.getActivity(
+                        /* context = */ context,
+                        /* requestCode = */ 0,
+                        /* intent = */ Intent(context, ViewStoriesActivity::class.java),
+                        /* flags = */ pendingIntentFlags
+                    )
+                    setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    setSmallIcon(R.drawable.ic_notification)
+                    setContentTitle(context.getString(R.string.notifTitle_inactivityAlert))
+                    setContentText(context.getString(R.string.notifMessage_inactivityAlert))
+                    setContentIntent(pendingIntent)
+                    setAutoCancel(true)
+                }
+            }
+        }
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.alert
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.android.journal3.Journal3.Companion.journal3Application
+import com.hadisatrio.apps.android.journal3.notification.NotificationChannel
+import com.hadisatrio.apps.kotlin.journal3.Router
+import com.hadisatrio.apps.kotlin.journal3.alert.AlertInactivityUseCase
+import com.hadisatrio.libs.android.foundation.modal.NotificationModalPresenter
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+@Suppress("unused")
+class InactivityAlertingWork(
+    private val context: Context,
+    workerParams: WorkerParameters
+) : Worker(context, workerParams) {
+
+    override fun doWork(): Result {
+        AlertInactivityUseCase(
+            threshold = context.journal3Application.inactivityAlertThreshold,
+            stories = context.journal3Application.stories,
+            presenter = NotificationModalPresenter(
+                context = context,
+                contentAdapter = InactivityAlertModalNotificationBuilderAdapter(
+                    context = context,
+                    channel = NotificationChannel.ALERT_AND_REMINDERS
+                ),
+            ),
+            eventSource = NoOpEventSource(),
+            eventSink = context.journal3Application.globalEventSink,
+            router = NoOpRouter()
+        )()
+        return Result.success()
+    }
+
+    private class NoOpEventSource : EventSource {
+        override fun events(): Flow<Event> {
+            return flowOf(CompletionEvent())
+        }
+    }
+
+    @Suppress("EmptyFunctionBlock")
+    private class NoOpRouter : Router {
+        override fun toStoryEditor() {}
+        override fun toMomentEditor(id: Uuid, storyId: Uuid) {}
+        override fun toMomentEditor(storyId: Uuid) {}
+        override fun toStoryEditor(id: Uuid) {}
+        override fun toStoryDetail(id: Uuid) {}
+        override fun toMomentDetail(id: Uuid) {}
+        override fun toPrevious() {}
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWorkInitializer.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWorkInitializer.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.alert
+
+import android.content.Context
+import androidx.startup.Initializer
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.WorkManagerInitializer
+import com.hadisatrio.apps.android.journal3.Journal3.Companion.journal3Application
+import java.util.concurrent.TimeUnit
+
+@Suppress("unused")
+class InactivityAlertingWorkInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        val workManager = WorkManager.getInstance(context)
+
+        val workRequestBuilder = PeriodicWorkRequestBuilder<InactivityAlertingWork>(
+            repeatInterval = context.journal3Application.inactivityAlertThreshold.inWholeMilliseconds,
+            repeatIntervalTimeUnit = TimeUnit.MILLISECONDS
+        )
+
+        workManager.enqueueUniquePeriodicWork(
+            /* uniqueWorkName = */ InactivityAlertingWork::class.java.simpleName,
+            /* existingPeriodicWorkPolicy = */ ExistingPeriodicWorkPolicy.REPLACE,
+            /* periodicWork = */ workRequestBuilder.build()
+        )
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> {
+        return mutableListOf(WorkManagerInitializer::class.java)
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -97,7 +97,8 @@ class EditAMomentActivity : AppCompatActivity() {
                     )
                 ),
                 eventSink = journal3Application.globalEventSink,
-                router = ActivityRouter(this)
+                router = ActivityRouter(this),
+                clock = journal3Application.clock
             )
         )()
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/notification/NotificationChannel.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/notification/NotificationChannel.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.notification
+
+import android.app.NotificationManager
+import android.content.Context
+import android.content.res.Resources
+import android.os.Build
+import androidx.annotation.StringRes
+import androidx.core.app.NotificationManagerCompat
+import com.hadisatrio.apps.android.journal3.R
+
+enum class NotificationChannel(
+    val id: String,
+    @StringRes
+    private val nameResId: Int,
+    @StringRes
+    private val descriptionResId: Int,
+    @StringRes
+    private val importance: Int
+) {
+
+    ALERT_AND_REMINDERS(
+        id = "68683bb1-d1e0-488e-8569-c711b3167617",
+        nameResId = R.string.notifChannelName_alertsReminders,
+        descriptionResId = R.string.notifChannelDesc_alertsReminders,
+        importance = NotificationManagerCompat.IMPORTANCE_DEFAULT
+    );
+
+    fun create(context: Context) {
+        create(context.resources, context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager)
+    }
+
+    fun create(resources: Resources, notificationManager: NotificationManager) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = resources.getString(nameResId)
+            val description = resources.getString(descriptionResId)
+            val channel = android.app.NotificationChannel(id, name, importance)
+            channel.description = description
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/notification/NotificationChannelInitializer.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/notification/NotificationChannelInitializer.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.notification
+
+import android.content.Context
+import androidx.startup.Initializer
+
+@Suppress("unused")
+class NotificationChannelInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        NotificationChannel.values().forEach { it.create(context) }
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> {
+        return mutableListOf()
+    }
+}

--- a/app-android-journal3/src/main/res/drawable/ic_notification.xml
+++ b/app-android-journal3/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <group>
+        <clip-path android:pathData="M12,12m-10,0a10,10 0,1 1,20 0a10,10 0,1 1,-20 0" />
+        <path
+            android:fillAlpha="0.5"
+            android:fillColor="#000000"
+            android:pathData="M10.353,2h9.529v20h-9.529z" />
+        <path
+            android:fillAlpha="0.75"
+            android:fillColor="#000000"
+            android:pathData="M19.882,2h5.765v20h-5.765z" />
+        <path
+            android:fillAlpha="0.25"
+            android:fillColor="#000000"
+            android:pathData="M-5.059,2h15.412v20h-15.412z" />
+    </group>
+</vector>

--- a/app-android-journal3/src/main/res/values/strings.xml
+++ b/app-android-journal3/src/main/res/values/strings.xml
@@ -17,4 +17,10 @@
 
 <resources>
     <string name="app_name">Journal3</string>
+
+    <string name="notifChannelName_alertsReminders">Alert &amp; Reminders</string>
+    <string name="notifChannelDesc_alertsReminders">Timely alert and reminders to help keep your journaling habit on track.</string>
+
+    <string name="notifTitle_inactivityAlert">What have you been up to?</string>
+    <string name="notifMessage_inactivityAlert">Good memories often consist of many small, seemingly uninteresting moments. Don\'t let them slip away.</string>
 </resources>

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.alert
+
+import com.hadisatrio.apps.kotlin.journal3.Router
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.story.Stories
+import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
+import kotlin.time.Duration
+
+class AlertInactivityUseCase(
+    private val threshold: Duration,
+    private val stories: Stories,
+    private val presenter: Presenter<Modal>,
+    private val eventSource: EventSource,
+    private val eventSink: EventSink,
+    private val router: Router
+) : UseCase {
+
+    override fun invoke() {
+        if (!isAlertNecessary()) return
+        presenter.present(BinaryConfirmationModal("inactivity_alert"))
+        observeEvents()
+    }
+
+    private fun isAlertNecessary(): Boolean {
+        if (!stories.hasMoments()) return true
+        val currentTimestamp = Timestamp(Clock.System.now())
+        val mostRecentTimestamp = stories.mostRecentMoment().timestamp
+        return currentTimestamp.difference(mostRecentTimestamp) > threshold
+    }
+
+    private fun observeEvents() = runBlocking {
+        eventSource.events().onEach { eventSink.sink(it) }
+            .takeWhile { event -> (event as? CompletionEvent)?.also { handleCompletion() } == null }
+            .collect { event -> handle(event) }
+    }
+
+    private fun handle(event: Event) {
+        if (event !is ModalApprovalEvent || event.modalKind != "inactivity_alert") return
+        router.toMomentEditor(stories.first().id)
+    }
+
+    private fun handleCompletion() {
+        router.toPrevious()
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
@@ -18,6 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
+import kotlin.time.Duration
 
 @JvmInline
 value class Timestamp(
@@ -28,6 +29,10 @@ value class Timestamp(
 
     fun toEpochMilliseconds(): Long {
         return value.toEpochMilliseconds()
+    }
+
+    fun difference(other: Timestamp): Duration {
+        return this.value - other.value
     }
 
     override fun compareTo(other: Timestamp): Int {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
@@ -18,17 +18,20 @@
 package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
-import kotlin.jvm.JvmInline
 
 @JvmInline
 value class Timestamp(
     private val value: Instant
-) {
+) : Comparable<Timestamp> {
 
     constructor(iso8601: String) : this(Instant.parse(iso8601))
 
     fun toEpochMilliseconds(): Long {
         return value.toEpochMilliseconds()
+    }
+
+    override fun compareTo(other: Timestamp): Int {
+        return value.compareTo(other.value)
     }
 
     override fun toString(): String {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -20,6 +20,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.hadisatrio.apps.kotlin.journal3.Router
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.id.TargetId
+import com.hadisatrio.apps.kotlin.journal3.moment.datetime.ClockRespectingMoments
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
@@ -38,6 +39,7 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.runBlocking
+import kotlinx.datetime.Clock
 
 @Suppress("LongParameterList")
 class EditAMomentUseCase(
@@ -48,7 +50,8 @@ class EditAMomentUseCase(
     private val modalPresenter: Presenter<Modal>,
     private val eventSource: EventSource,
     private val eventSink: EventSink,
-    private val router: Router
+    private val router: Router,
+    private val clock: Clock
 ) : UseCase {
 
     private lateinit var currentTarget: Moment
@@ -63,7 +66,9 @@ class EditAMomentUseCase(
         currentTarget = if (targetId.isValid()) {
             stories.findMoment(targetId.asUuid()).first()
         } else {
-            stories.findStory(storyId.asUuid()).first().moments.new()
+            val story = stories.findStory(storyId.asUuid()).first()
+            val moments = ClockRespectingMoments(clock, story.moments)
+            moments.new()
         }
     }
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
@@ -22,6 +22,8 @@ import com.benasher44.uuid.Uuid
 interface Moments : Iterable<Moment> {
     fun new(): Moment
 
+    fun count(): Int
+
     fun find(id: Uuid): Iterable<Moment>
 
     fun mostRecent(): Moment

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
@@ -23,4 +23,6 @@ interface Moments : Iterable<Moment> {
     fun new(): Moment
 
     fun find(id: Uuid): Iterable<Moment>
+
+    fun mostRecent(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/datetime/ClockRespectingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/datetime/ClockRespectingMoments.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment.datetime
+
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import kotlinx.datetime.Clock
+
+class ClockRespectingMoments(
+    private val clock: Clock,
+    private val origin: Moments
+) : Moments by origin {
+
+    override fun new(): Moment {
+        val moment = origin.new()
+        moment.update(Timestamp(clock.now()))
+        return moment
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -43,6 +43,10 @@ class FilesystemMoments(
         }
     }
 
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
+    }
+
     override fun iterator(): Iterator<Moment> {
         fileSystem.createDirectories(dir = path, mustCreate = false)
         return fileSystem.list(path).map { path -> FilesystemMoment(fileSystem, path) }.iterator()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -34,6 +34,10 @@ class FilesystemMoments(
         return FilesystemMoment(fileSystem, path, uuid4())
     }
 
+    override fun count(): Int {
+        return fileSystem.list(path).size
+    }
+
     override fun find(id: Uuid): Iterable<Moment> {
         val candidatePath = path / id.toString()
         if (fileSystem.exists(candidatePath)) {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
@@ -26,4 +26,6 @@ interface Stories : Iterable<Story> {
     fun findStory(id: Uuid): Iterable<Story>
 
     fun findMoment(id: Uuid): Iterable<Moment>
+
+    fun mostRecentMoment(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
@@ -25,6 +25,8 @@ interface Stories : Iterable<Story> {
 
     fun findStory(id: Uuid): Iterable<Story>
 
+    fun hasMoments(): Boolean
+
     fun findMoment(id: Uuid): Iterable<Moment>
 
     fun mostRecentMoment(): Moment

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -24,11 +24,14 @@ import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import okio.FileSystem
 import okio.Path
+import okio.Path.Companion.toPath
 
 class FilesystemStories(
     private val fileSystem: FileSystem,
     private val path: Path
 ) : Stories {
+
+    constructor(fileSystem: FileSystem, path: String) : this(fileSystem, path.toPath())
 
     override fun new(): Story {
         fileSystem.createDirectories(dir = path, mustCreate = false)
@@ -42,6 +45,10 @@ class FilesystemStories(
         } else {
             return emptyList()
         }
+    }
+
+    override fun hasMoments(): Boolean {
+        return any { story -> story.moments.count() > 0 }
     }
 
     override fun findMoment(id: Uuid): Iterable<Moment> {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -48,6 +48,15 @@ class FilesystemStories(
         return flatMap { it.moments.find(id) }
     }
 
+    override fun mostRecentMoment(): Moment {
+        val recentMoments = mutableListOf<Moment>()
+        forEach { story ->
+            if (!story.moments.iterator().hasNext()) return@forEach
+            recentMoments.add(story.moments.mostRecent())
+        }
+        return recentMoments.maxBy { it.timestamp }
+    }
+
     override fun iterator(): Iterator<Story> {
         fileSystem.createDirectories(dir = path, mustCreate = false)
         return fileSystem.list(path).map { path -> FilesystemStory(fileSystem, path) }.iterator()

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.alert
+
+import com.hadisatrio.apps.kotlin.journal3.Router
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.event.RecordedEventSource
+import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
+import com.hadisatrio.apps.kotlin.journal3.story.FakeStories
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.datetime.Clock
+import org.junit.Test
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+
+class AlertInactivityUseCaseTest {
+
+    @Test
+    fun `Presents a modal should last written moment timestamp exceeds threshold`() {
+        val presenter = mockk<Presenter<Modal>>(relaxed = true)
+        val stories = FakeStories()
+        val story = stories.new()
+        val moment = story.moments.new()
+        moment.update(Timestamp(Clock.System.now() - 1.days))
+
+        AlertInactivityUseCase(
+            threshold = 3.hours,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                CompletionEvent()
+            ),
+            eventSink = mockk(relaxed = true),
+            router = mockk(relaxed = true)
+        )()
+
+        verify(exactly = 1) { presenter.present(withArg { it.kind.shouldBe("inactivity_alert") }) }
+    }
+
+    @Test
+    fun `Presents a modal should no moments have ever been written`() {
+        val presenter = mockk<Presenter<Modal>>(relaxed = true)
+        val stories = FakeStories()
+
+        AlertInactivityUseCase(
+            threshold = 3.hours,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                CompletionEvent()
+            ),
+            eventSink = mockk(relaxed = true),
+            router = mockk(relaxed = true)
+        )()
+
+        verify(exactly = 1) { presenter.present(withArg { it.kind.shouldBe("inactivity_alert") }) }
+    }
+
+    @Test
+    fun `Does nothing should last written moment timestamp is under threshold`() {
+        val presenter = mockk<Presenter<Modal>>(relaxed = true)
+        val stories = FakeStories()
+        val story = stories.new()
+        val moment = story.moments.new()
+        moment.update(Timestamp(Clock.System.now() - 1.hours))
+
+        AlertInactivityUseCase(
+            threshold = 3.hours,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                CompletionEvent()
+            ),
+            eventSink = mockk(relaxed = true),
+            router = mockk(relaxed = true)
+        )()
+
+        verify(inverse = true) { presenter.present(any()) }
+    }
+
+    @Test
+    fun `Routes to the moment editor when receiving modal approval for 'inactivity_alert'`() {
+        val router = mockk<Router>(relaxed = true)
+        val stories = FakeStories()
+        val story = stories.new()
+        val moment = story.moments.new()
+        moment.update(Timestamp(Clock.System.now() - 1.days))
+
+        AlertInactivityUseCase(
+            threshold = 3.hours,
+            stories = stories,
+            presenter = mockk(relaxed = true),
+            eventSource = RecordedEventSource(
+                ModalApprovalEvent("inactivity_alert"),
+                CompletionEvent()
+            ),
+            eventSink = mockk(relaxed = true),
+            router = router
+        )()
+
+        verify(exactly = 1) { router.toMomentEditor(story.id) }
+    }
+
+    @Test
+    fun `Ignores unknown events without repercussions`() {
+        val stories = FakeStories()
+        val story = stories.new()
+        val moment = story.moments.new()
+        moment.update(Timestamp(Clock.System.now() - 1.days))
+
+        AlertInactivityUseCase(
+            threshold = 3.hours,
+            stories = stories,
+            presenter = mockk(relaxed = true),
+            eventSource = RecordedEventSource(
+                ModalApprovalEvent("foo"),
+                UnsupportedEvent(),
+                CompletionEvent()
+            ),
+            eventSink = mockk(relaxed = true),
+            router = mockk(relaxed = true)
+        )()
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
@@ -39,6 +39,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import kotlin.test.Test
 
@@ -65,7 +66,8 @@ class EditAMomentUseCaseTest {
                 CompletionEvent()
             ),
             eventSink = mockk(relaxed = true),
-            router = mockk(relaxed = true)
+            router = mockk(relaxed = true),
+            clock = Clock.System
         )()
 
         story.moments.shouldHaveSize(1)
@@ -94,7 +96,8 @@ class EditAMomentUseCaseTest {
                 CompletionEvent()
             ),
             eventSink = mockk(relaxed = true),
-            router = mockk(relaxed = true)
+            router = mockk(relaxed = true),
+            clock = Clock.System
         )()
 
         story.moments.shouldHaveSize(1)
@@ -125,7 +128,8 @@ class EditAMomentUseCaseTest {
                 CompletionEvent()
             ),
             eventSink = mockk(relaxed = true),
-            router = mockk(relaxed = true)
+            router = mockk(relaxed = true),
+            clock = Clock.System
         )()
 
         verify(exactly = 1) { modalPresenter.present(withArg { it.kind.shouldBe("edit_cancellation_confirmation") }) }
@@ -153,7 +157,8 @@ class EditAMomentUseCaseTest {
                 ModalApprovalEvent("edit_cancellation_confirmation")
             ),
             eventSink = mockk(relaxed = true),
-            router = mockk(relaxed = true)
+            router = mockk(relaxed = true),
+            clock = Clock.System
         )()
 
         verify(exactly = 1) { modalPresenter.present(withArg { it.kind.shouldBe("edit_cancellation_confirmation") }) }
@@ -182,7 +187,8 @@ class EditAMomentUseCaseTest {
                 CompletionEvent()
             ),
             eventSink = mockk(relaxed = true),
-            router = mockk(relaxed = true)
+            router = mockk(relaxed = true),
+            clock = Clock.System
         )()
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoments.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoments.kt
@@ -32,6 +32,10 @@ class FakeMoments(
         return moment
     }
 
+    override fun count(): Int {
+        return moments.size
+    }
+
     override fun find(id: Uuid): Iterable<Moment> {
         return filter { it.id == id }
     }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoments.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoments.kt
@@ -36,6 +36,10 @@ class FakeMoments(
         return filter { it.id == id }
     }
 
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
+    }
+
     override fun iterator(): Iterator<Moment> {
         return moments.iterator()
     }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/datetime/ClockRespectingMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/datetime/ClockRespectingMomentsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment.datetime
+
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.moment.FakeMoments
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.datetime.Clock
+import kotlin.test.Test
+import kotlin.time.Duration
+
+class ClockRespectingMomentsTest {
+
+    @Test
+    fun `Ensures newly-created moments are updated with current timestamp`() {
+        val clock = mockk<Clock>()
+        val origin = FakeMoments()
+        val moments = ClockRespectingMoments(clock, origin)
+        val current = Clock.System.now()
+        val currentTimestamp = Timestamp(current)
+        every { clock.now() } returns current
+
+        val moment = moments.new()
+
+        moment.timestamp.difference(currentTimestamp).shouldBe(Duration.ZERO)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -78,6 +79,18 @@ class FilesystemMomentsTest {
         val found = story.moments.find(uuid4())
 
         found.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Fetches its most recent moment`() {
+        val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, stories)
+        val story = stories.first()
+
+        val mostRecent = story.moments.mostRecent()
+
+        story.moments.filterNot { it.id == mostRecent.id }.forEach { other ->
+            other.timestamp.compareTo(mostRecent.timestamp).shouldBeLessThan(0)
+        }
     }
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
@@ -61,6 +61,15 @@ class FilesystemMomentsTest {
     }
 
     @Test
+    fun `Counts its moments`() {
+        val story = stories.new()
+
+        repeat(10) { story.moments.new().update(TokenableString("Foo")) }
+
+        story.moments.shouldHaveSize(10)
+    }
+
+    @Test
     fun `Finds a moment by its ID`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, stories)
         val story = stories.first()

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/FakeStories.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/FakeStories.kt
@@ -41,6 +41,15 @@ class FakeStories(
         return flatMap { it.moments.find(id) }
     }
 
+    override fun mostRecentMoment(): Moment {
+        val recentMoments = mutableListOf<Moment>()
+        forEach { story ->
+            if (!story.moments.iterator().hasNext()) return@forEach
+            recentMoments.add(story.moments.mostRecent())
+        }
+        return recentMoments.maxBy { it.timestamp }
+    }
+
     override fun iterator(): Iterator<Story> {
         return stories.iterator()
     }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/FakeStories.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/FakeStories.kt
@@ -37,6 +37,10 @@ class FakeStories(
         return filter { it.id == id }
     }
 
+    override fun hasMoments(): Boolean {
+        return any { story -> story.moments.count() > 0 }
+    }
+
     override fun findMoment(id: Uuid): Iterable<Moment> {
         return flatMap { it.moments.find(id) }
     }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
@@ -19,6 +19,7 @@ package com.hadisatrio.apps.kotlin.journal3.story.filesystem
 
 import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
+import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
@@ -32,7 +33,7 @@ import kotlin.test.Test
 class FilesystemStoriesTest {
 
     private val fileSystem = FakeFileSystem()
-    private val stories = FilesystemStories(fileSystem, "content".toPath())
+    private val stories = FilesystemStories(fileSystem, "content")
 
     @AfterTest
     fun `Closes all file streams`() {
@@ -48,6 +49,15 @@ class FilesystemStoriesTest {
         stories.shouldHaveSize(1)
         story.title.shouldBe("Foo")
         fileSystem.metadata("content/${story.id}".toPath()).isDirectory.shouldBeTrue()
+    }
+
+    @Test
+    fun `Tells whether or not it contains any moments within`() {
+        val empty = FilesystemStories(fileSystem, "Foo")
+        val nonEmpty = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, FilesystemStories(fileSystem, "Bar"))
+
+        empty.hasMoments().shouldBeFalse()
+        nonEmpty.hasMoments().shouldBeTrue()
     }
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
@@ -22,6 +22,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -85,5 +86,17 @@ class FilesystemStoriesTest {
         val found = stories.findMoment(uuid4())
 
         found.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Fetches its most recent moment`() {
+        val stories = SelfPopulatingStories(noOfStories = 9, noOfMoments = 10, stories)
+        stories.new().update("Foo") // ...add a story with no moments to increase variety.
+
+        val mostRecentMoment = stories.mostRecentMoment()
+
+        stories.flatMap { it.moments }.filterNot { it.id == mostRecentMoment.id }.forEach { other ->
+            other.timestamp.compareTo(mostRecentMoment.timestamp).shouldBeLessThan(0)
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -5,6 +5,11 @@ object Dependencies {
     object AndroidArchitecture {
         const val VIEWMODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
         const val LIFECYCLE = "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
+        const val STARTUP = "androidx.startup:startup-runtime:1.1.1"
+    }
+
+    object AndroidAsynchrony {
+        const val WORKMANAGER = "androidx.work:work-runtime-ktx:2.7.1"
     }
 
     object AndroidCompatibility {

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/modal/NotificationModalPresenter.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/modal/NotificationModalPresenter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.modal
+
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.presentation.Adapter
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+
+class NotificationModalPresenter(
+    private val context: Context,
+    private val contentAdapter: Adapter<Modal, NotificationBuilderFactory>
+) : Presenter<Modal> {
+
+    override fun present(thing: Modal) {
+        val builder = contentAdapter.adapt(thing).create()
+        val manager = NotificationManagerCompat.from(context)
+        manager.notify(thing.kind.hashCode(), builder.build())
+    }
+
+    interface NotificationBuilderFactory {
+        fun create(): NotificationCompat.Builder
+    }
+}

--- a/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/modal/NotificationModalPresenterTest.kt
+++ b/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/modal/NotificationModalPresenterTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.modal
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.core.app.NotificationCompat
+import androidx.test.runner.AndroidJUnit4
+import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(AndroidJUnit4::class)
+class NotificationModalPresenterTest {
+
+    @Test
+    fun `Presents given modal through a Notification`() {
+        val activityController = Robolectric.buildActivity(ComponentActivity::class.java).setup().visible()
+        val activity = activityController.get()
+        val notificationManager = activity.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val shadowNotificationManager = shadowOf(notificationManager)
+        val builderFactory = object : NotificationModalPresenter.NotificationBuilderFactory {
+            override fun create(): NotificationCompat.Builder {
+                return NotificationCompat.Builder(activity, "Foo").apply {
+                    setSmallIcon(0)
+                    setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    setContentTitle("Fizz")
+                    setContentText("Buzz")
+                }
+            }
+        }
+
+        NotificationModalPresenter(activity, { builderFactory }).present(BinaryConfirmationModal("Foo"))
+
+        shadowNotificationManager.allNotifications.size.shouldBe(1)
+        shadowNotificationManager.allNotifications.first().channelId.shouldBe("Foo")
+    }
+}


### PR DESCRIPTION
### What has changed
Added a new use-case to alert users if they haven't recorded any moments after a certain duration had passed (currently set to 3 hours). On the Android app, this use-case would be run on top of the WorkManager API and would talk to a notification-backed presenter; resulting in a periodical notification setup.

### Why was it changed
Because I need this feature to help keep my journaling habit in check.

### Related issues
- N/A