### PR TITLE
Sort moments on screen according to their timestamp

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentsRecyclerViewPresenter.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentsRecyclerViewPresenter.kt
@@ -44,7 +44,7 @@ class MomentsRecyclerViewPresenter(
 
     override fun present(thing: Moments) {
         setupRecyclerView()
-        adapter.submitList(thing.map { "${it.timestamp}\n${it.description}\n${it.sentiment}" })
+        adapter.submitList(thing.sortedDescending().map { "${it.timestamp}\n${it.description}\n${it.sentiment}" })
     }
 
     private fun setupRecyclerView() = with(recyclerView) {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
@@ -22,7 +22,7 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
-interface Moment {
+interface Moment : Comparable<Moment> {
     val id: Uuid
     val timestamp: Timestamp
     val description: TokenableString

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
@@ -76,4 +76,8 @@ class FilesystemMoment : Moment {
     override fun forget() {
         file.delete()
     }
+
+    override fun compareTo(other: Moment): Int {
+        return timestamp.compareTo(other.timestamp)
+    }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoment.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FakeMoment.kt
@@ -57,4 +57,8 @@ class FakeMoment(
         isForgotten = true
         group.remove(this)
     }
+
+    override fun compareTo(other: Moment): Int {
+        return timestamp.compareTo(other.timestamp)
+    }
 }


### PR DESCRIPTION
### What has changed
Moments shown in the story detail screen are now sorted, in descending order, according to their timestamp.

### Why was it changed
To make it easier to read back written moments from the past. Unless they are sorted in some way, the user won't be able to make sense of the timeline in which their moments took place.