### PR TITLE
Defer write operations during edit until absolutely necessary

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
@@ -35,5 +35,6 @@ interface Moment : Comparable<Moment> {
     fun update(description: TokenableString)
     fun update(sentiment: Sentiment)
     fun update(place: Place)
+
     fun forget()
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMoment.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.kotlin.geography.Place
+
+class UpdateDeferringMoment(
+    private val origin: Moment
+) : Moment by origin {
+
+    private var timestampInEdit: Timestamp = origin.timestamp
+    private var descriptionInEdit: TokenableString = origin.description
+    private var sentimentInEdit: Sentiment = origin.sentiment
+    private var placeInEdit: Place = origin.place
+
+    override val timestamp: Timestamp get() = timestampInEdit
+    override val description: TokenableString get() = descriptionInEdit
+    override val sentiment: Sentiment get() = sentimentInEdit
+    override val place: Place get() = placeInEdit
+
+    override fun update(timestamp: Timestamp) {
+        timestampInEdit = timestamp
+    }
+
+    override fun update(description: TokenableString) {
+        descriptionInEdit = description
+    }
+
+    override fun update(sentiment: Sentiment) {
+        sentimentInEdit = sentiment
+    }
+
+    override fun update(place: Place) {
+        placeInEdit = place
+    }
+
+    override fun compareTo(other: Moment): Int {
+        return timestampInEdit.compareTo(other.timestamp)
+    }
+
+    fun updatesMade(): Boolean {
+        return timestampInEdit != origin.timestamp ||
+            descriptionInEdit != origin.description ||
+            sentimentInEdit != origin.sentiment ||
+            placeInEdit != origin.place
+    }
+
+    fun commit() {
+        origin.update(timestampInEdit)
+        origin.update(descriptionInEdit)
+        origin.update(sentimentInEdit)
+        origin.update(placeInEdit)
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -37,7 +37,7 @@ class FilesystemMoments(
     }
 
     override fun count(): Int {
-        return fileSystem.list(path).size
+        return if (fileSystem.exists(path).not()) 0 else fileSystem.list(path).size
     }
 
     override fun find(id: Uuid): Iterable<Moment> {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStory.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+
+class UpdateDeferringStory(
+    private val origin: Story
+) : Story by origin {
+
+    private var titleInEdit: String = origin.title
+    private var synopsisInEdit: TokenableString = origin.synopsis
+
+    override val title: String get() = titleInEdit
+    override val synopsis: TokenableString get() = synopsisInEdit
+
+    override fun update(title: String) {
+        this.titleInEdit = title
+    }
+
+    override fun update(synopsis: TokenableString) {
+        this.synopsisInEdit = synopsis
+    }
+
+    fun updatesMade(): Boolean {
+        return titleInEdit != origin.title || synopsisInEdit != origin.synopsis
+    }
+
+    fun commit() {
+        origin.update(titleInEdit)
+        origin.update(synopsisInEdit)
+    }
+}


### PR DESCRIPTION
### What has changed

We now defer actual write operations (in form of `update()` calls to the model) during editing through `UpdateDeferring` proxies. 

### Why was it changed

To conserve performance. As a nice side-effect, this would also fix the clunky edit cancellation behavior as the proxies allow for a more elaborate series of checks.