### PR TITLE
Update Minimum and Compile SDK versions

### DIFF
--- a/app-android-journal3/src/main/AndroidManifest.xml
+++ b/app-android-journal3/src/main/AndroidManifest.xml
@@ -22,7 +22,9 @@
     package="com.hadisatrio.apps.android.journal3">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".RealJournal3Application"

--- a/app-kmm-journal3/build.gradle.kts
+++ b/app-kmm-journal3/build.gradle.kts
@@ -69,11 +69,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = Dependencies.AndroidSdk.COMPILE
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 21
-        targetSdk = 32
+        minSdk = Dependencies.AndroidSdk.MINIMUM
+        targetSdk = Dependencies.AndroidSdk.TARGET
     }
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -2,6 +2,12 @@
 
 object Dependencies {
 
+    object AndroidSdk {
+        const val MINIMUM = 23
+        const val COMPILE = 33
+        const val TARGET = 32
+    }
+
     object AndroidArchitecture {
         const val VIEWMODEL = "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
         const val LIFECYCLE = "androidx.lifecycle:lifecycle-runtime-ktx:2.4.0"
@@ -65,7 +71,7 @@ object Dependencies {
         const val COROUTINES_TEST = "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.6.2"
         const val KOTEST_ASSERTIONS = "io.kotest:kotest-assertions-core:5.4.2"
         const val ESPRESSO = "androidx.test.espresso:espresso-core:3.4.0"
-        const val ROBOLECTRIC = "org.robolectric:robolectric:4.8.2"
+        const val ROBOLECTRIC = "org.robolectric:robolectric:4.10.2"
     }
 
     object TestDouble {

--- a/buildSrc/src/main/kotlin/plugin/AndroidBenchmarkConfigurationPlugin.kt
+++ b/buildSrc/src/main/kotlin/plugin/AndroidBenchmarkConfigurationPlugin.kt
@@ -15,7 +15,7 @@ class AndroidBenchmarkConfigurationPlugin : Plugin<Project> {
 
         project.extensions.getByType<BaseExtension>().run {
             defaultConfig {
-                minSdk = 23
+                minSdk = Dependencies.AndroidSdk.MINIMUM
                 testInstrumentationRunner("androidx.benchmark.junit4.AndroidBenchmarkRunner")
             }
 

--- a/buildSrc/src/main/kotlin/plugin/ProjectConfigureAndroid.kt
+++ b/buildSrc/src/main/kotlin/plugin/ProjectConfigureAndroid.kt
@@ -1,5 +1,6 @@
 package plugin
 
+import Dependencies
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.getByType
 import com.android.build.gradle.BaseExtension
@@ -10,11 +11,12 @@ internal fun Project.configureAndroid() {
 
     this.extensions.getByType<BaseExtension>().run {
 
-        compileSdkVersion(32)
+        compileSdkVersion(Dependencies.AndroidSdk.COMPILE)
         buildToolsVersion("7.2.1")
 
         defaultConfig {
-            minSdk = 21
+            minSdk = Dependencies.AndroidSdk.MINIMUM
+            targetSdk = Dependencies.AndroidSdk.TARGET
             consumerProguardFiles("$rootDir/proguard/proguard-rules.pro")
             testInstrumentationRunner("androidx.test.runner.AndroidJUnitRunner")
         }

--- a/lib-kmm-foundation/build.gradle.kts
+++ b/lib-kmm-foundation/build.gradle.kts
@@ -79,11 +79,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = Dependencies.AndroidSdk.COMPILE
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 21
-        targetSdk = 32
+        minSdk = Dependencies.AndroidSdk.MINIMUM
+        targetSdk = Dependencies.AndroidSdk.TARGET
     }
     testOptions {
         unitTests {

--- a/lib-kmm-geography/build.gradle.kts
+++ b/lib-kmm-geography/build.gradle.kts
@@ -79,11 +79,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = Dependencies.AndroidSdk.COMPILE
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 21
-        targetSdk = 32
+        minSdk = Dependencies.AndroidSdk.MINIMUM
+        targetSdk = Dependencies.AndroidSdk.TARGET
     }
     testOptions {
         unitTests {

--- a/lib-kmm-json/build.gradle.kts
+++ b/lib-kmm-json/build.gradle.kts
@@ -64,11 +64,11 @@ kotlin {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = Dependencies.AndroidSdk.COMPILE
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
-        minSdk = 21
-        targetSdk = 32
+        minSdk = Dependencies.AndroidSdk.MINIMUM
+        targetSdk = Dependencies.AndroidSdk.TARGET
     }
     testOptions {
         unitTests {


### PR DESCRIPTION
### What has changed

This PR will update:
- `compileSdk` to `33` 
- `minSdk` to `23`

#### Why was it changed
To unblock Renovate's automated dependency update PRs.