### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,14 +20,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Check with Gradle
-        run: ./gradlew clean check
-
-      - name: Analyze with SonarCloud
+      - name: Build with Gradle and SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew clean build sonarqube
-
-      - name: Build with Gradle
-        run: ./gradlew clean build

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -20,10 +20,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Check with Gradle
-        run: ./gradlew clean check
-
-      - name: Analyze with SonarCloud
+      - name: Build with Gradle and SonarCloud
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Enables build caching.
 org.gradle.caching=true
 
+# Enables parallel builds.
+org.gradle.parallel=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,10 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+
+# Enables build caching.
+org.gradle.caching=true
+
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -15,10 +19,13 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
 # Enables namespacing of each library's R class so that its R class includes only the
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,3 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
-
-


### PR DESCRIPTION
### What has changed

#### `org.gradle.caching=true`

Leverage [build-caching](https://docs.gradle.org/current/userguide/build_cache.html) to speed up both CI and local builds alike. I had no idea that this was not enabled by default as evident in [this Build Scan output](https://scans.gradle.com/s/4ysikcpfjqcx4/performance/build-cache). 

#### Removal of redundant `build` tasks in CI
We have been running `check` and `build` repeatedly in both Actions YAML. Inherently, `build` would also include `check` so we can do away with the explicit call.

### Why was it changed

To speed up CI, especially important now that we have Renovate making automated PRs.

