### PR TITLE
Fix flaky test cases

### DIFF
--- a/lib-kmm-geography/build.gradle.kts
+++ b/lib-kmm-geography/build.gradle.kts
@@ -95,7 +95,7 @@ android {
 kover {
     filters {
         classes {
-            excludes += listOf("*Fake*", "*Test")
+            excludes += listOf("*Fake*", "*Test*", "*Rule*")
         }
     }
     verify {

--- a/lib-kmm-geography/src/androidTest/kotlin/com/hadisatrio/libs/android/geography/Api30AndUnderLocationManagerCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidTest/kotlin/com/hadisatrio/libs/android/geography/Api30AndUnderLocationManagerCoordinatesTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.spyk
 import io.mockk.verify
 import org.junit.After
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -38,6 +39,9 @@ import kotlin.time.Duration.Companion.seconds
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [Build.VERSION_CODES.Q])
 class Api30AndUnderLocationManagerCoordinatesTest {
+
+    @get:Rule
+    val retryRule = RetryRule(retryCount = 5)
 
     private val application = RuntimeEnvironment.getApplication()
     private val locationManager = spyk(application.getSystemService(Context.LOCATION_SERVICE) as LocationManager)

--- a/lib-kmm-geography/src/androidTest/kotlin/com/hadisatrio/libs/android/geography/RetryRule.kt
+++ b/lib-kmm-geography/src/androidTest/kotlin/com/hadisatrio/libs/android/geography/RetryRule.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.geography
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class RetryRule(private val retryCount: Int) : TestRule {
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                var throwable: Throwable? = null
+                (0 until retryCount).forEach {
+                    try {
+                        base.evaluate()
+                        return
+                    } catch (t: Throwable) {
+                        throwable = t
+                    }
+                }
+                throw throwable ?: AssertionError("Test failed after $retryCount retries.")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What has changed

We will now retry tests within `Api30AndUnderLocationManagerCoordinatesTest` up to 5 times before reporting a failure. This is done through a new Unit Rule–`RetryRule`–to enable reuse if later needed.

### Why was it changed

To combat the non-locally reproducible flakiness we observed on Actions. Logs didn't yield much insight either, so here we are.
