### PR TITLE
Fix unresponsive Back button

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -150,6 +150,7 @@ class EditAMomentUseCase(
             modalPresenter.present(modal)
         } else {
             isEditCancelled = true
+            completionEvents.emit(CompletionEvent())
         }
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCase.kt
@@ -124,6 +124,7 @@ class EditAStoryUseCase(
             modalPresenter.present(modal)
         } else {
             isEditCancelled = true
+            completionEvents.emit(CompletionEvent())
         }
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
@@ -169,8 +169,7 @@ class EditAMomentUseCaseTest {
                 TextInputEvent("description", ""),
                 SelectionEvent("sentiment", Sentiment(0.75F).toString()),
                 SelectionEvent("sentiment", Sentiment.DEFAULT.toString()),
-                CancellationEvent("user"),
-                CompletionEvent()
+                CancellationEvent("user")
             ),
             eventSink = mockk(relaxed = true),
             clock = Clock.System

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
@@ -140,8 +140,7 @@ class EditAStoryUseCaseTest {
                 TextInputEvent("synopsis", "Bar"),
                 TextInputEvent("title", ""),
                 TextInputEvent("synopsis", ""),
-                CancellationEvent("user"),
-                CompletionEvent()
+                CancellationEvent("user")
             ),
             eventSink = mockk(relaxed = true)
         )()


### PR DESCRIPTION
### What has changed

`EditAStoryUseCase` and `EditAMomentUseCase` will now properly emit `CompletionEvent` internally upon receiving `CancellationEvent` if no meaningful edits has been made.

### Why was it changed

Otherwise the Back button (or any kind of back navigation measures) would not work in that scenario.
