### PR TITLE
Support story deletion

### DIFF
--- a/app-android-journal3/src/main/AndroidManifest.xml
+++ b/app-android-journal3/src/main/AndroidManifest.xml
@@ -72,6 +72,9 @@
 
         <activity android:name=".story.EditAStoryActivity" />
 
+        <activity android:name=".story.DeleteAStoryActivity"
+            android:theme="@style/Theme.Journal3.Translucent" />
+
         <activity android:name=".moment.EditAMomentActivity" />
 
         <activity android:name=".geography.SelectAPlaceActivity" />

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
@@ -21,6 +21,7 @@ import android.app.Activity
 import android.content.Intent
 import com.hadisatrio.apps.android.journal3.geography.SelectAPlaceActivity
 import com.hadisatrio.apps.android.journal3.moment.EditAMomentActivity
+import com.hadisatrio.apps.android.journal3.story.DeleteAStoryActivity
 import com.hadisatrio.apps.android.journal3.story.EditAStoryActivity
 import com.hadisatrio.apps.android.journal3.story.ViewStoryActivity
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
@@ -39,6 +40,7 @@ class ActivityRoutingEventSink(
         when (identifier) {
             "add_story" -> activity.startActivity(Intent(activity, EditAStoryActivity::class.java))
             "edit_story" -> activity.startEditAStoryActivity(event)
+            "delete_story" -> activity.startDeleteAStoryActivity(event)
             "view_story" -> activity.startViewStoryActivity(event)
             "add_moment" -> activity.startAddAMomentActivity(event)
             "edit_moment" -> activity.startEditAMomentActivity(event)
@@ -54,6 +56,12 @@ class ActivityRoutingEventSink(
 
     private fun Activity.startEditAStoryActivity(event: SelectionEvent) {
         val intent = Intent(this, EditAStoryActivity::class.java)
+        intent.putExtra("target_id", event["story_id"])
+        startActivity(intent)
+    }
+
+    private fun Activity.startDeleteAStoryActivity(event: SelectionEvent) {
+        val intent = Intent(this, DeleteAStoryActivity::class.java)
         intent.putExtra("target_id", event["story_id"])
         startActivity(intent)
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -120,7 +120,7 @@ class RealJournal3Application : Journal3Application() {
     }
 
     override val backgroundExecutor: Executor by lazy {
-        Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())
+        Executors.newCachedThreadPool()
     }
 
     override val foregroundExecutor: Executor by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.story
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.hadisatrio.apps.android.journal3.id.BundledTargetId
+import com.hadisatrio.apps.android.journal3.journal3Application
+import com.hadisatrio.apps.kotlin.journal3.story.DeleteStoryUseCase
+import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
+import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
+
+class DeleteAStoryActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        ExecutorDispatchingUseCase(
+            executor = journal3Application.backgroundExecutor,
+            origin = DeleteStoryUseCase(
+                targetId = BundledTargetId(intent, "target_id"),
+                stories = journal3Application.stories,
+                presenter = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = journal3Application.modalPresenter
+                ),
+                eventSource = EventSources(
+                    journal3Application.globalEventSource
+                ),
+                eventSink = EventSinks(
+                    journal3Application.globalEventSink,
+                    ActivityCompletionEventSink(this)
+                )
+            )
+        )()
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.Lifecycle
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.id.BundledTargetId
 import com.hadisatrio.apps.android.journal3.journal3Application
+import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.story.EditAStoryUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
@@ -36,12 +37,14 @@ import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
+import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 
 class EditAStoryActivity : AppCompatActivity() {
 
+    @Suppress("LongMethod")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -72,12 +75,21 @@ class EditAStoryActivity : AppCompatActivity() {
                         journal3Application.globalEventSource,
                         LifecycleTriggeredEventSource(
                             lifecycleOwner = this,
+                            lifecycleEvent = Lifecycle.Event.ON_RESUME,
+                            eventFactory = { RefreshRequestEvent("lifecycle") }
+                        ),
+                        LifecycleTriggeredEventSource(
+                            lifecycleOwner = this,
                             lifecycleEvent = Lifecycle.Event.ON_DESTROY,
                             eventFactory = { CancellationEvent("system") }
                         ),
                         ViewClickEventSource(
                             view = findViewById(R.id.add_button),
                             eventFactory = { CompletionEvent() }
+                        ),
+                        ViewClickEventSource(
+                            view = findViewById(R.id.delete_button),
+                            eventFactory = { SelectionEvent("action", "delete") }
                         ),
                         EditTextInputEventSource(
                             editText = findViewById(R.id.title_text_field),

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -26,6 +26,7 @@ import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
+import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
@@ -33,6 +34,7 @@ import com.hadisatrio.libs.android.foundation.widget.TextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
@@ -107,12 +109,19 @@ class ViewStoryActivity : AppCompatActivity() {
                             view = findViewById(R.id.edit_button),
                             eventFactory = { SelectionEvent("action", "edit") }
                         ),
+                        ViewClickEventSource(
+                            view = findViewById(R.id.delete_button),
+                            eventFactory = { SelectionEvent("action", "delete") }
+                        ),
                         RecyclerViewItemSelectionEventSource(
                             recyclerView = findViewById(R.id.moments_list)
                         )
                     )
                 ),
-                eventSink = journal3Application.globalEventSink
+                eventSink = EventSinks(
+                    journal3Application.globalEventSink,
+                    ActivityCompletionEventSink(this)
+                )
             )
         )()
     }

--- a/app-android-journal3/src/main/res/drawable/ic_delete.xml
+++ b/app-android-journal3/src/main/res/drawable/ic_delete.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:height="24dp"
+    android:tint="#000000"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    android:width="24dp"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,19c0,1.1 0.9,2 2,2h8c1.1,0 2,-0.9 2,-2V7H6v12zM19,4h-3.5l-1,-1h-5l-1,1H5v2h14V4z" />
+</vector>

--- a/app-android-journal3/src/main/res/layout/activity_edit_a_story.xml
+++ b/app-android-journal3/src/main/res/layout/activity_edit_a_story.xml
@@ -54,6 +54,15 @@
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/delete_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:src="@drawable/ic_delete"
+        app:layout_constraintBottom_toTopOf="@id/add_button"
+        app:layout_constraintStart_toStartOf="@id/add_button" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/add_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app-android-journal3/src/main/res/layout/activity_view_story.xml
+++ b/app-android-journal3/src/main/res/layout/activity_view_story.xml
@@ -69,6 +69,15 @@
         android:layout_height="wrap_content"
         android:layout_margin="@dimen/margin"
         android:src="@drawable/ic_add"
+        app:layout_constraintBottom_toTopOf="@id/delete_button"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/delete_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin"
+        android:src="@drawable/ic_delete"
         app:layout_constraintBottom_toTopOf="@id/edit_button"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app-android-journal3/src/main/res/values/themes.xml
+++ b/app-android-journal3/src/main/res/values/themes.xml
@@ -30,4 +30,13 @@
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
         <!-- Customize your theme here. -->
     </style>
+
+    <style name="Theme.Journal3.Translucent" parent="Theme.Journal3">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowIsFloating">true</item>
+        <item name="android:backgroundDimEnabled">false</item>
+    </style>
 </resources>

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/id/InvalidTargetId.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/id/InvalidTargetId.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.id
+
+import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuidFrom
+
+object InvalidTargetId : TargetId {
+
+    override fun asUuid(): Uuid {
+        return uuidFrom("00000000-0000-0000-0000-000000000000")
+    }
+
+    override fun isValid(): Boolean {
+        return false
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCase.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.id.TargetId
+import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.runBlocking
+
+class DeleteStoryUseCase(
+    private val targetId: TargetId,
+    private val stories: Stories,
+    private val presenter: Presenter<Modal>,
+    private val eventSource: EventSource,
+    private val eventSink: EventSink
+) : UseCase {
+
+    private val completionEvents by lazy { MutableSharedFlow<CompletionEvent>(extraBufferCapacity = 1) }
+
+    override fun invoke() = runBlocking {
+        present()
+        observeEvents()
+    }
+
+    private fun present() {
+        val modal = if (stories.containsStory(targetId.asUuid())) {
+            BinaryConfirmationModal("story_deletion_confirmation")
+        } else {
+            BinaryConfirmationModal("story_not_found_notification")
+        }
+        presenter.present(modal)
+    }
+
+    private suspend fun observeEvents() {
+        merge(eventSource.events(), completionEvents)
+            .onEach { eventSink.sink(it) }
+            .takeWhile { event -> (event as? CompletionEvent) == null }
+            .collect { event -> handle(event) }
+    }
+
+    private suspend fun handle(event: Event) {
+        when (event) {
+            is ModalApprovalEvent -> handleApproval(event)
+            is ModalDismissalEvent -> handleDismissal()
+        }
+    }
+
+    private suspend fun handleApproval(event: ModalApprovalEvent) {
+        when (event.modalKind) {
+            "story_not_found_notification" -> {
+                completionEvents.emit(CompletionEvent())
+            }
+            "story_deletion_confirmation" -> {
+                stories.findStory(targetId.asUuid()).first().forget()
+                completionEvents.emit(CompletionEvent())
+            }
+        }
+    }
+
+    private suspend fun handleDismissal() {
+        completionEvents.emit(CompletionEvent())
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
@@ -23,6 +23,8 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 interface Stories : Iterable<Story> {
     fun new(): Story
 
+    fun containsStory(id: Uuid): Boolean
+
     fun findStory(id: Uuid): Iterable<Story>
 
     fun hasMoments(): Boolean

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
@@ -35,6 +35,10 @@ class FakeStories(
         return story
     }
 
+    override fun containsStory(id: Uuid): Boolean {
+        return findStory(id).count() > 0
+    }
+
     override fun findStory(id: Uuid): Iterable<Story> {
         return filter { it.id == id }
     }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -44,6 +44,10 @@ class FilesystemStories(
         return FilesystemStory(fileSystem, path, uuid4(), memorables)
     }
 
+    override fun containsStory(id: Uuid): Boolean {
+        return findStory(id).count() > 0
+    }
+
     override fun findStory(id: Uuid): Iterable<Story> {
         val candidatePath = path / id.toString()
         if (fileSystem.exists(candidatePath)) {

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
@@ -21,7 +21,7 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RecordedEventSource
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.id.FakeTargetId
-import com.hadisatrio.apps.kotlin.journal3.id.TargetId
+import com.hadisatrio.apps.kotlin.journal3.id.InvalidTargetId
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
@@ -39,7 +39,6 @@ import com.hadisatrio.libs.kotlin.geography.fake.FakePlaces
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.datetime.Clock
@@ -85,14 +84,12 @@ class EditAMomentUseCaseTest {
 
     @Test
     fun `Updates a new moment when target ID is invalid`() {
-        val targetId = mockk<TargetId>()
         val places = SelfPopulatingPlaces(noOfPlaces = 1, origin = FakePlaces())
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
         val story = stories.first()
-        every { targetId.isValid() } returns false
 
         EditAMomentUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             storyId = FakeTargetId(story.id),
             stories = stories,
             places = places,
@@ -116,16 +113,14 @@ class EditAMomentUseCaseTest {
 
     @Test
     fun `Prevents accidental cancellation by the user when a meaningful edit has been made`() {
-        val targetId = mockk<TargetId>()
         val places = SelfPopulatingPlaces(noOfPlaces = 1, origin = FakePlaces())
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
         val place = places.first()
         val story = stories.first()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAMomentUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             storyId = FakeTargetId(story.id),
             stories = stories,
             places = places,
@@ -151,14 +146,12 @@ class EditAMomentUseCaseTest {
 
     @Test
     fun `Does not prevent accidental cancellation by the user when a meaningful edit has not been made`() {
-        val targetId = mockk<TargetId>()
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
         val story = stories.first()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAMomentUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             storyId = FakeTargetId(story.id),
             stories = stories,
             places = FakePlaces(),
@@ -183,14 +176,12 @@ class EditAMomentUseCaseTest {
 
     @Test
     fun `Deletes the moment-in-edit when it is a new one and the user cancels without editing`() {
-        val targetId = mockk<TargetId>()
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
         val story = stories.first()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAMomentUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             storyId = FakeTargetId(story.id),
             stories = stories,
             places = FakePlaces(),
@@ -264,14 +255,12 @@ class EditAMomentUseCaseTest {
 
     @Test
     fun `Ignores unknown events without repercussions`() {
-        val targetId = mockk<TargetId>()
         val places = SelfPopulatingPlaces(noOfPlaces = 1, origin = FakePlaces())
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
         val story = stories.first()
-        every { targetId.isValid() } returns false
 
         EditAMomentUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             storyId = FakeTargetId(story.id),
             stories = stories,
             places = places,

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCaseTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.event.RecordedEventSource
+import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
+import com.hadisatrio.apps.kotlin.journal3.id.FakeTargetId
+import com.hadisatrio.apps.kotlin.journal3.id.InvalidTargetId
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSink
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
+import com.hadisatrio.libs.kotlin.foundation.presentation.fake.FakePresenter
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class DeleteStoryUseCaseTest {
+
+    private val stories = SelfPopulatingStories(1, 1, FakeStories())
+    private val story = stories.first()
+    private val targetId = FakeTargetId(story.id)
+    private val presenter = FakePresenter<Modal>()
+    private val eventSink = FakeEventSink()
+
+    @Test
+    fun `Deletes the story after the user confirms the request`() {
+        DeleteStoryUseCase(
+            targetId = targetId,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                ModalApprovalEvent("story_deletion_confirmation")
+            ),
+            eventSink = eventSink
+        )()
+
+        presenter.presentedCount().shouldBe(1)
+        presenter.hasPresented { it.kind == "story_deletion_confirmation" }.shouldBeTrue()
+        stories.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Don't delete the story if the user don't confirm the request`() {
+        DeleteStoryUseCase(
+            targetId = targetId,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                ModalDismissalEvent("story_deletion_confirmation")
+            ),
+            eventSink = eventSink
+        )()
+
+        presenter.presentedCount().shouldBe(1)
+        presenter.hasPresented { it.kind == "story_deletion_confirmation" }.shouldBeTrue()
+        stories.shouldNotBeEmpty()
+    }
+
+    @Test
+    fun `Informs the user if the story could not be found`() {
+        listOf(
+            ModalApprovalEvent("story_not_found_notification"),
+            ModalDismissalEvent("story_not_found_notification")
+        ).forEach { event ->
+            DeleteStoryUseCase(
+                targetId = InvalidTargetId,
+                stories = stories,
+                presenter = presenter,
+                eventSource = RecordedEventSource(event),
+                eventSink = eventSink
+            )()
+
+            presenter.hasPresented { it.kind == "story_not_found_notification" }.shouldBeTrue()
+            stories.shouldNotBeEmpty()
+        }
+    }
+
+    @Test
+    fun `Does nothing when given an unsupported event`() {
+        DeleteStoryUseCase(
+            targetId = InvalidTargetId,
+            stories = stories,
+            presenter = presenter,
+            eventSource = RecordedEventSource(
+                ModalApprovalEvent("foo"),
+                ModalDismissalEvent("foo"),
+                UnsupportedEvent(),
+                CompletionEvent()
+            ),
+            eventSink = eventSink
+        )()
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
@@ -22,7 +22,7 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RecordedEventSource
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.id.FakeTargetId
-import com.hadisatrio.apps.kotlin.journal3.id.TargetId
+import com.hadisatrio.apps.kotlin.journal3.id.InvalidTargetId
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
@@ -38,7 +38,6 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.datetime.Instant
@@ -71,12 +70,10 @@ class EditAStoryUseCaseTest {
 
     @Test
     fun `Updates a new story when target ID is invalid`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
-        every { targetId.isValid() } returns false
 
         EditAStoryUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             stories = stories,
             presenter = mockk(relaxed = true),
             modalPresenter = mockk(relaxed = true),
@@ -95,13 +92,11 @@ class EditAStoryUseCaseTest {
 
     @Test
     fun `Prevents accidental cancellation by the user when a meaningful edit has been made`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAStoryUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             stories = stories,
             presenter = mockk(relaxed = true),
             modalPresenter = modalPresenter,
@@ -125,13 +120,11 @@ class EditAStoryUseCaseTest {
 
     @Test
     fun `Does not prevent accidental cancellation by the user when a meaningful edit has not been made`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAStoryUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             stories = stories,
             presenter = mockk(relaxed = true),
             modalPresenter = modalPresenter,
@@ -153,13 +146,11 @@ class EditAStoryUseCaseTest {
 
     @Test
     fun `Deletes the story-in-edit when it is a new one and the user cancels without editing`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
-        every { targetId.isValid() } returns false
 
         EditAStoryUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             stories = stories,
             presenter = mockk(relaxed = true),
             modalPresenter = modalPresenter,
@@ -207,13 +198,11 @@ class EditAStoryUseCaseTest {
 
     @Test(timeout = 5_000)
     fun `Stops upon receiving cancellation events`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
-        every { targetId.isValid() } returns false
 
         listOf(CancellationEvent("system")).forEach { event ->
             EditAStoryUseCase(
-                targetId = targetId,
+                targetId = InvalidTargetId,
                 stories = stories,
                 presenter = mockk(relaxed = true),
                 modalPresenter = mockk(relaxed = true),
@@ -225,12 +214,10 @@ class EditAStoryUseCaseTest {
 
     @Test(timeout = 5_000)
     fun `Ignores unknown events without repercussions`() {
-        val targetId = mockk<TargetId>()
         val stories = FakeStories()
-        every { targetId.isValid() } returns false
 
         EditAStoryUseCase(
-            targetId = targetId,
+            targetId = InvalidTargetId,
             stories = stories,
             presenter = mockk(relaxed = true),
             modalPresenter = mockk(relaxed = true),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoryUseCaseTest.kt
@@ -109,6 +109,35 @@ class ShowStoryUseCaseTest {
     }
 
     @Test
+    fun `Forwards to the sink when action 'delete' is selected`() {
+        val story = stories.first()
+        val targetId = FakeTargetId(story.id)
+        val eventSink = mockk<EventSink>(relaxed = true)
+
+        ShowStoryUseCase(
+            targetId = targetId,
+            stories = stories,
+            presenter = mockk(relaxed = true),
+            eventSource = RecordedEventSource(
+                SelectionEvent("action", "delete"),
+                CompletionEvent()
+            ),
+            eventSink = eventSink
+        )()
+
+        verify(exactly = 1) {
+            eventSink.sink(
+                withArg { event ->
+                    event["name"].shouldBe("Selection Event")
+                    event["selection_kind"].shouldBe("action")
+                    event["selected_id"].shouldBe("delete_story")
+                    event["story_id"].shouldBe(story.id.toString())
+                }
+            )
+        }
+    }
+
+    @Test
     fun `Forwards to the sink when action 'edit' is selected`() {
         val story = stories.first()
         val targetId = FakeTargetId(story.id)
@@ -194,6 +223,8 @@ class ShowStoryUseCaseTest {
             stories = stories,
             presenter = mockk(relaxed = true),
             eventSource = RecordedEventSource(
+                SelectionEvent("foo", "foo"),
+                SelectionEvent("action", "foo"),
                 UnsupportedEvent(),
                 CompletionEvent()
             ),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
@@ -70,6 +70,15 @@ class FilesystemStoriesTest {
     }
 
     @Test
+    fun `Reports whether or not it contains a story basing on its ID`() {
+        val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, stories)
+        val story = stories.first()
+
+        stories.containsStory(story.id).shouldBeTrue()
+        stories.containsStory(uuid4()).shouldBeFalse()
+    }
+
+    @Test
     fun `Finds a story by its ID`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, stories)
         val story = stories.first()

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/presentation/fake/FakePresenter.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/presentation/fake/FakePresenter.kt
@@ -23,6 +23,14 @@ class FakePresenter<T> : Presenter<T> {
 
     private val presented = mutableListOf<T>()
 
+    fun presentedCount(): Int {
+        return presented.size
+    }
+
+    fun hasPresented(thingThat: (T) -> Boolean): Boolean {
+        return presented.any(thingThat)
+    }
+
     override fun present(thing: T) {
         presented += thing
     }


### PR DESCRIPTION
### What has changed

#### It's possible to delete stories now

Stories can now be deleted, introducing a new use-case. Additionally, a new activity has been added to host the execution of this use-case. The deletion flow can be triggered from two places: the story details and editor screens.

#### Execute background tasks through a cached thread pool

With the addition of more use-cases, each blocking a thread until it completes, there is an increasing likelihood of exhausting the fixed thread pool. This looks like a potential design flaw that we should investigate further.

### Why was it changed

This implementation provided a good opportunity to evaluate how the architecture handles a flow that mandated both state management and navigational handoff between multiple use-cases. By introducing story deletion as a dedicated use-case, we were able to reduce duplication. However, this approach also brings about a challenge of cascading back navigation once the deletion flow is complete.

To address this, we have leveraged `RefreshRequestEvent` in each relevant use-case to hook in a validity check. However, the effectiveness of this approach in the long run remains to be seen.