### PR TITLE
Fix unexpected window resizing in moment editor

### DIFF
--- a/app-android-journal3/src/main/res/values/themes.xml
+++ b/app-android-journal3/src/main/res/values/themes.xml
@@ -17,10 +17,13 @@
 
 <resources>
 
-    <style name="Theme.Journal3" parent="Theme.Material3.DayNight" />
+    <style name="Theme.Journal3" parent="Theme.Material3.DayNight">
+        <item name="android:windowSoftInputMode">adjustPan</item>
+    </style>
 
     <style name="Theme.Journal3.NoActionBar" parent="Theme.Material3.DayNight.NoActionBar">
         <item name="android:windowTranslucentStatus">true</item>
+        <item name="android:windowSoftInputMode">adjustPan</item>
     </style>
 
     <style name="Theme.Journal3.Translucent" parent="Theme.Journal3">


### PR DESCRIPTION
### What has changed

We now explicitly state what `windowSoftInputMode` to use through `@style/Theme.Journal3`.

### Why was it changed

To address the issue (perhaps mistakenly) reported [here](https://github.com/material-components/material-components-android/issues/3452). It was never an issue with `BottomBar`. Rather, the inherent feature of `Window` originally described [here](https://android-developers.narkive.com/hQ2JkGbv/default-adjust-for-android-windowsoftinputmode).