### PR TITLE
Fix broken URI operations around image files

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFile.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFile.kt
@@ -53,7 +53,17 @@ class FilesystemMemorableFile(
 
     override val uri: Uri
         get() {
-            return Uri.fromParts(scheme = "file", path = path.toString())
+            return Uri.fromParts(
+                scheme = "file",
+                // The following is a hack to overcome the fact that Uri, the class, doesn't allow
+                // empty host. Uri will always honor the original RFC when it comes to the '://' part.
+                // That is, it won't add the '//' part if the host is empty, which don't play well with
+                // the 'file' scheme.
+                // The method internally would only do a substringAfter("://") when it's sanitizing
+                // the host part, hence the following.
+                host = "://",
+                path = path.toString()
+            )
         }
 
     override fun link(momentId: Uuid) {

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FilesystemMemorableFileTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/FilesystemMemorableFileTest.kt
@@ -27,6 +27,7 @@ import com.hadisatrio.libs.kotlin.json.JsonFile
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import kotlinx.serialization.json.JsonPrimitive
 import okio.Path
@@ -108,5 +109,10 @@ class FilesystemMemorableFileTest {
         file.unlink(oneMomentId)
         file.unlink(otherMomentId)
         files.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Produces a valid URI of itself`() {
+        file.uri.uriString.shouldBe("file:///$internalDirPath/${file.id}")
     }
 }

--- a/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/widget/PhotoSelectionEventSourceTest.kt
+++ b/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/widget/PhotoSelectionEventSourceTest.kt
@@ -46,7 +46,7 @@ class PhotoSelectionEventSourceTest {
     fun `Produces SelectionEvent upon positive activity result`() = runTest {
         val expectedResult = listOf(Uri.parse("content://foo"), Uri.parse("content://bar"))
         val registry = immediateReturningRegistry(expectedResult)
-        val source = PhotoSelectionEventSource(triggerView, activity, registry)
+        val source = PhotoSelectionEventSource(triggerView, activity, registry, activity.contentResolver)
         val events = mutableListOf<Event>()
         activity.setContentView(triggerView)
         activityController.setup().visible()
@@ -64,7 +64,7 @@ class PhotoSelectionEventSourceTest {
     @Test
     fun `Does not produce SelectionEvent upon negative activity result`() = runTest {
         val registry = immediateReturningRegistry(emptyList<Uri>())
-        val source = PhotoSelectionEventSource(triggerView, activity, registry)
+        val source = PhotoSelectionEventSource(triggerView, activity, registry, activity.contentResolver)
         val events = mutableListOf<Event>()
         activity.setContentView(triggerView)
         activityController.setup().visible()


### PR DESCRIPTION
### What has changed

#### Persist URI read access via `ContentResolver`

We now request for the permission to be persisted through [`ContentResolver#takePersistableUriPermission()`](https://developer.android.com/reference/android/content/ContentResolver.html#takePersistableUriPermission(android.net.Uri,%20int)) within the `ActivityResultCallback` in `PhotoSelectionEventSource`.

#### File URI ensured to have `://`

When producing an `Uri`, `FilesystemMemorableFile` will now attempt a "hack" to ensure the resulting value would have `://` in between the scheme and host.

### Why was it changed

While running the app on a Pixel 3a XL with Android 13, persisting images from the system's photo picker would crash the app.

```
Process: com.hadisatrio.apps.android.journal3, PID: 32368
java.lang.SecurityException: Permission Denial: reading com.android.providers.media.MediaDocumentsProvider uri content://com.android.providers.media.documents/document/image%3A65 from pid=32368, uid=10250 requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs
	at android.os.Parcel.createExceptionOrNull(Parcel.java:2425)
	at android.os.Parcel.createException(Parcel.java:2409)
	at android.os.Parcel.readException(Parcel.java:2392)
	at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:190)
	at android.database.DatabaseUtils.readExceptionWithFileNotFoundExceptionFromParcel(DatabaseUtils.java:153)
	at android.content.ContentProviderProxy.openTypedAssetFile(ContentProviderNative.java:780)
	at android.content.ContentResolver.openTypedAssetFileDescriptor(ContentResolver.java:2027)
	at android.content.ContentResolver.openAssetFileDescriptor(ContentResolver.java:1842)
	at android.content.ContentResolver.openInputStream(ContentResolver.java:1518)
	at com.hadisatrio.libs.android.io.content.ContentResolverSources.open(ContentResolverSources.kt:39)
	at com.hadisatrio.libs.kotlin.io.SchemeWiseSources.open(SchemeWiseSources.kt:33)
	at com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFiles.toContentAwareUuid(FilesystemMemorableFiles.kt:95)
	at com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFiles.relate(FilesystemMemorableFiles.kt:38)
	at com.hadisatrio.apps.kotlin.journal3.moment.MemorablesCollection.relate(MemorablesCollection.kt:33)
	...
```

As this operation subjects are URI strings, rather than the same `android.net.Uri` instance the system gave, the permission would've been lost.

Similarly, Glide threw an error when loading images that have already been persisted.

```
class com.bumptech.glide.load.engine.GlideException: Failed to load resource [file:data/user/0/com.hadisatrio.apps.android.journal3/files/content/attachments/61f9105c-5676-33b7-b1b0-9f95e2e91533] with dimensions [333x333]
There was 1 root cause:
java.lang.NullPointerException(null)
 call GlideException#logRootCauses(String) for more detail
  Cause (1 of 1): class java.lang.NullPointerException: 
  ...
  java.lang.NullPointerException
    at java.io.FileInputStream.<init>(FileInputStream.java:152)
	at java.io.FileInputStream.<init>(FileInputStream.java:115)
	at android.content.ContentResolver.openInputStream(ContentResolver.java:1516)
```

This turned out to be caused by the `URI` returned from `FilesystemMemorableFile`, which follows this form:

> `file:<path>`

And `<path>` in this case does not have a prepending `/`.