### PR TITLE
Fix inconsistent ordering of stories and moments

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -55,6 +55,9 @@ class FilesystemMoments(
 
     override fun iterator(): Iterator<Moment> {
         fileSystem.createDirectories(dir = path, mustCreate = false)
-        return fileSystem.list(path).map { path -> FilesystemMoment(fileSystem, path, memorables) }.iterator()
+        val paths = fileSystem.list(path).asSequence()
+        val moments = paths.map { path -> FilesystemMoment(fileSystem, path, memorables) }
+        val sorted = moments.sortedDescending()
+        return sorted.iterator()
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
@@ -22,7 +22,7 @@ import com.hadisatrio.apps.kotlin.journal3.forgettable.Forgettable
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
-interface Story : Forgettable {
+interface Story : Forgettable, Comparable<Story> {
     val id: Uuid
     val title: String
     val synopsis: TokenableString

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
@@ -51,4 +51,8 @@ class FakeStory(
         isForgotten = true
         group.remove(this)
     }
+
+    override fun compareTo(other: Story): Int {
+        return title.compareTo(other.title)
+    }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -80,6 +80,9 @@ class FilesystemStories(
 
     override fun iterator(): Iterator<Story> {
         fileSystem.createDirectories(dir = path, mustCreate = false)
-        return fileSystem.list(path).map { path -> FilesystemStory(fileSystem, path, memorables) }.iterator()
+        val paths = fileSystem.list(path).asSequence()
+        val stories = paths.map { path -> FilesystemStory(fileSystem, path, memorables) }
+        val sorted = stories.sorted()
+        return sorted.iterator()
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
@@ -80,4 +80,8 @@ class FilesystemStory(
     override fun forget() {
         fileSystem.deleteRecursively(directory)
     }
+
+    override fun compareTo(other: Story): Int {
+        return title.compareTo(other.title)
+    }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFileTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFileTest.kt
@@ -15,12 +15,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.moment
+package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.uuid4
 import com.chrynan.uri.core.Uri
-import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFile
-import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFiles
 import com.hadisatrio.libs.kotlin.io.filesystem.FileSystemSources
 import com.hadisatrio.libs.kotlin.io.uri.toUri
 import com.hadisatrio.libs.kotlin.json.JsonFile

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFilesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFilesTest.kt
@@ -15,12 +15,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.moment
+package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.chrynan.uri.core.Uri
-import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFiles
+import com.hadisatrio.apps.kotlin.journal3.moment.MemorableFile
 import com.hadisatrio.libs.kotlin.io.filesystem.FileSystemSources
 import com.hadisatrio.libs.kotlin.io.uri.toUri
 import com.hadisatrio.libs.kotlin.json.JsonFile


### PR DESCRIPTION
### What has changed

`FilesystemStories` and `FilesystemMoments` now sort their items during `iterator()`.

### Why it was changed

To avoid confusion during usage, we need to ensure that the order of these are consistent between sessions. Previously they were solely dependent on the result of `FileSystem#list` which can change especially when a new item got added.