### PR TITLE
Fix ungraceful handling of invalid touch events

### DIFF
--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewItemSelectionEventSource.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewItemSelectionEventSource.kt
@@ -48,7 +48,8 @@ class RecyclerViewItemSelectionEventSource(
                         }
                         event.action == MotionEvent.ACTION_UP && isBeingPressed -> {
                             markEndOfPress()
-                            val touched = view.findChildViewUnder(event.x, event.y)!!
+                            val touched = view.findChildViewUnder(event.x, event.y)
+                            if (touched == null) return super.onInterceptTouchEvent(view, event)
                             val position = view.getChildAdapterPosition(touched)
                             trySend(SelectionEvent("item_position", position.toString()))
                         }

--- a/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewItemSelectionEventSourceTest.kt
+++ b/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewItemSelectionEventSourceTest.kt
@@ -90,6 +90,54 @@ class RecyclerViewItemSelectionEventSourceTest {
     }
 
     @Test
+    fun `Doesn't do anything if touch happens outside of child's boundaries`() = runTest {
+        val recyclerView = RecyclerView(RuntimeEnvironment.getApplication())
+        val events = mutableListOf<Event>()
+        recyclerView.layoutManager = LinearLayoutManager(RuntimeEnvironment.getApplication())
+        recyclerView.adapter = Adapter(listOf("Foo", "Bar", "Fizz", "Buzz"))
+        recyclerView.measure(0, 0)
+        recyclerView.layout(0, 0, 1000, 1000)
+
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            RecyclerViewItemSelectionEventSource(recyclerView).events().toList(events)
+        }
+        recyclerView.dispatchTouchEvent(
+            MotionEvent.obtain(
+                /* downTime = */
+                System.currentTimeMillis(),
+                /* eventTime = */
+                System.currentTimeMillis(),
+                /* action = */
+                MotionEvent.ACTION_DOWN,
+                /* x = */
+                recyclerView.getChildAt(0).x,
+                /* y = */
+                recyclerView.getChildAt(0).y + 800F,
+                /* metaState = */
+                0
+            )
+        )
+        recyclerView.dispatchTouchEvent(
+            MotionEvent.obtain(
+                /* downTime = */
+                System.currentTimeMillis(),
+                /* eventTime = */
+                System.currentTimeMillis(),
+                /* action = */
+                MotionEvent.ACTION_UP,
+                /* x = */
+                recyclerView.getChildAt(0).x,
+                /* y = */
+                recyclerView.getChildAt(0).y + 800F,
+                /* metaState = */
+                0
+            )
+        )
+
+        collectJob.cancel()
+    }
+
+    @Test
     fun `Tolerates slight movement whilst registering click events`() = runTest {
         val recyclerView = RecyclerView(RuntimeEnvironment.getApplication())
         val events = mutableListOf<Event>()


### PR DESCRIPTION
### What has changed

The `RecyclerViewItemSelectionEventSource` will no longer encounter a `NullPointerException` when handling touch events outside of the bounds of available children.

### Why it was changed
Because the previous behavior was causing crashes in the app.