### PR TITLE
Fix UI issues around timestamps

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
@@ -26,11 +26,11 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
-import androidx.fragment.app.FragmentActivity
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.libs.android.fragment.supportFragmentManager
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -70,7 +70,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
     override fun onClick(p0: View?) {
         if (activePicker != null) return
 
-        val fragmentManager = (context as? FragmentActivity)?.supportFragmentManager ?: return
+        val fragmentManager = this.supportFragmentManager ?: return
         val datePicker = MaterialDatePicker.Builder.datePicker()
             .setSelection(this.selection.toEpochMilliseconds())
             .build()
@@ -112,7 +112,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
             state.getLong(STATE_SELECTION).let(::applySelection)
 
             if (state.getBoolean(STATE_HAS_ACTIVE_PICKER)) {
-                val fragmentManager = (context as? FragmentActivity)?.supportFragmentManager ?: return
+                val fragmentManager = this.supportFragmentManager ?: return
                 val fragmentTransaction = fragmentManager.beginTransaction()
                 val picker = fragmentManager.findFragmentByTag(FRAGMENT_TAG_PICKER)
                 if (picker != null) fragmentTransaction.remove(picker)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
@@ -131,7 +131,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
         applySelection(Timestamp(instant))
     }
 
-    private fun applySelection(timestamp: Timestamp) {
+    internal fun applySelection(timestamp: Timestamp) {
         selection = timestamp
         text = timestamp.toString()
         listener?.onTimeStampSelected(timestamp)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButtonPresenter.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButtonPresenter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.datetime
+
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+
+class TimestampSelectorButtonPresenter(
+    private val button: TimestampSelectorButton
+) : Presenter<Timestamp> {
+
+    override fun present(model: Timestamp) {
+        button.applySelection(model)
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -26,6 +26,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.datetime.TimestampSelectionEventSource
+import com.hadisatrio.apps.android.journal3.datetime.TimestampSelectorButtonPresenter
 import com.hadisatrio.apps.android.journal3.id.BundledTargetId
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
@@ -69,8 +70,8 @@ class EditAMomentActivity : AppCompatActivity() {
             executor = journal3Application.foregroundExecutor,
             origin = Presenters(
                 AdaptingPresenter(
-                    origin = TextViewStringPresenter(findViewById(R.id.timestamp_selector_button)),
-                    adapter = { moment -> moment.timestamp.toString() }
+                    origin = TimestampSelectorButtonPresenter(findViewById(R.id.timestamp_selector_button)),
+                    adapter = { moment -> moment.timestamp }
                 ),
                 AdaptingPresenter(
                     origin = TextViewStringPresenter(findViewById(R.id.place_selector_button)),

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/activity/Activities.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/activity/Activities.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.activity
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.View
+
+val View.activity: Activity?
+    get() = context.toActivity()
+
+tailrec fun Context.toActivity(): Activity? =
+    this as? Activity ?: (this as? ContextWrapper)?.baseContext?.toActivity()

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/fragment/FragmentManagers.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/fragment/FragmentManagers.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.fragment
+
+import android.view.View
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import com.hadisatrio.libs.android.activity.activity
+
+val View.supportFragmentManager: FragmentManager?
+    get() = (activity as? FragmentActivity)?.supportFragmentManager


### PR DESCRIPTION
### What has changed

#### Improved method for obtaining `Context` within `View` instances

We have introduced extensions that make it easier to retrieve the `Context` from within `View` instances.

#### Dedicated presenter for `TimestampSelectorButton`

A dedicated presenter has been implemented for `TimestampSelectorButton`. This presenter not only updates the button's text value but also manages the selection state of the button.

### Why it was changed

After using the application, it became apparent that the timestamp selector button was unresponsive. Upon further investigation, we discovered that the root cause was the casting of `as? FragmentActivity` within the button's logic. Starting from #83, views no longer have `Activity` as their direct context; rather `ContextThemeWrapper`.

Additionally, we identified an issue with the selection dialog that appears when the button is clicked. The dialog always displayed the default timestamp, regardless of any user-defined value. This problem arose because we were using a generic string presenter for buttons. While the user-facing value was updated correctly, the button's internal state remained unchanged until the user explicitly made a selection.