### PR TITLE
Fix broken state restoration during place selection

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -21,8 +21,8 @@ import android.app.Application
 import android.content.Context
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
-import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
@@ -36,7 +36,7 @@ abstract class Journal3Application : Application() {
     abstract val modalPresenter: Presenter<Modal>
     abstract val currentActivity: CurrentActivity
     abstract val globalEventSink: EventSink
-    abstract val globalEventSource: EventHub
+    abstract val globalEventSource: EventSource
     abstract val inactivityAlertThreshold: Duration
     abstract val clock: Clock
     abstract val backgroundExecutor: Executor

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -34,6 +34,7 @@ import com.hadisatrio.libs.android.io.content.ContentResolverSources
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -93,7 +94,7 @@ class RealJournal3Application : Journal3Application() {
     override val modalPresenter: Presenter<Modal> by lazy {
         ExecutorDispatchingPresenter(
             executor = foregroundExecutor,
-            origin = AlertDialogModalPresenter(currentActivity, globalEventSource)
+            origin = AlertDialogModalPresenter(currentActivity, globalEventSource as EventHub)
         )
     }
 
@@ -108,7 +109,7 @@ class RealJournal3Application : Journal3Application() {
         )
     }
 
-    override val globalEventSource: EventHub by lazy {
+    override val globalEventSource: EventSource by lazy {
         EventHub(MutableSharedFlow(extraBufferCapacity = 1))
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceSelectionEventSource.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceSelectionEventSource.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.geography
+
+import android.content.Context
+import android.content.Intent
+import android.view.View
+import androidx.activity.ComponentActivity
+import androidx.activity.result.ActivityResultRegistry
+import androidx.activity.result.contract.ActivityResultContract
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class PlaceSelectionEventSource internal constructor(
+    triggerView: View,
+    activity: ComponentActivity,
+    registry: ActivityResultRegistry
+) : EventSource {
+
+    private val events = MutableSharedFlow<Event>(extraBufferCapacity = 1)
+    private val launcher = activity.registerForActivityResult(SelectAPlace(), registry) { placeId ->
+        if (placeId.isNullOrBlank()) return@registerForActivityResult
+        events.tryEmit(SelectionEvent("place", placeId))
+    }
+
+    init {
+        triggerView.setOnClickListener { launcher.launch(Unit) }
+    }
+
+    constructor(triggerView: View, activity: ComponentActivity) : this(
+        triggerView,
+        activity,
+        activity.activityResultRegistry
+    )
+
+    override fun events(): Flow<Event> {
+        return events
+    }
+
+    private class SelectAPlace : ActivityResultContract<Unit, String>() {
+
+        override fun createIntent(context: Context, input: Unit): Intent {
+            return Intent(context, SelectAPlaceActivity::class.java)
+        }
+
+        override fun parseResult(resultCode: Int, intent: Intent?): String {
+            return intent?.getStringExtra("place") ?: ""
+        }
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -31,6 +31,7 @@ import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.geography.SelectAPlaceUseCase
 import com.hadisatrio.libs.android.dimensions.dp
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityResultSettingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.widget.BackButtonCancellationEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
@@ -44,7 +45,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
-import com.hadisatrio.libs.kotlin.foundation.event.FilteringEventSink
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
@@ -94,12 +94,18 @@ class SelectAPlaceActivity : AppCompatActivity() {
 
     private val eventSink: EventSink by lazy {
         EventSinks(
-            ActivityCompletionEventSink(this),
-            FilteringEventSink(
-                predicate = { it is SelectionEvent && it.selectionKind == "place" },
-                origin = journal3Application.globalEventSource
+            journal3Application.globalEventSink,
+            ActivityResultSettingEventSink(
+                activity = this,
+                adapter = { event ->
+                    val values = mutableMapOf<String, Any>()
+                    if (event is SelectionEvent && event.selectionKind == "place") {
+                        values["place"] = event.selectedIdentifier
+                    }
+                    values
+                }
             ),
-            journal3Application.globalEventSink
+            ActivityCompletionEventSink(this)
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -27,6 +27,7 @@ import com.bumptech.glide.Glide
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.datetime.TimestampSelectionEventSource
 import com.hadisatrio.apps.android.journal3.datetime.TimestampSelectorButtonPresenter
+import com.hadisatrio.apps.android.journal3.geography.PlaceSelectionEventSource
 import com.hadisatrio.apps.android.journal3.id.BundledTargetId
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
@@ -134,9 +135,9 @@ class EditAMomentActivity : AppCompatActivity() {
                     view = findViewById(R.id.commit_button),
                     eventFactory = { CompletionEvent() }
                 ),
-                ViewClickEventSource(
-                    view = findViewById(R.id.place_selector_button),
-                    eventFactory = { SelectionEvent("action", "select_place") }
+                PlaceSelectionEventSource(
+                    triggerView = findViewById(R.id.place_selector_button),
+                    activity = this
                 ),
                 TimestampSelectionEventSource(
                     button = findViewById(R.id.timestamp_selector_button)

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -24,6 +24,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSink
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -45,7 +46,7 @@ class FakeJournal3Application : Journal3Application() {
     override val modalPresenter: Presenter<Modal> by lazy { FakePresenter() }
     override val currentActivity: CurrentActivity by lazy { CurrentActivity(this) }
     override val globalEventSink: EventSink by lazy { FakeEventSink() }
-    override val globalEventSource: EventHub by lazy { EventHub(MutableSharedFlow(extraBufferCapacity = 1)) }
+    override val globalEventSource: EventSource by lazy { EventHub(MutableSharedFlow(extraBufferCapacity = 1)) }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val clock: Clock by lazy { Clock.System }
     override val backgroundExecutor: Executor by lazy { Executors.newFixedThreadPool(1) }

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityResultSettingEventSink.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityResultSettingEventSink.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.activity
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.presentation.Adapter
+import java.io.Serializable
+
+class ActivityResultSettingEventSink(
+    private val activity: Activity,
+    private val adapter: Adapter<Event, Map<String, Any>>
+) : EventSink {
+
+    override fun sink(event: Event) {
+        val values = adapter.adapt(event)
+        val intent = Intent().apply { putExtras(values.toBundle()) }
+        if (values.isEmpty()) return
+        activity.setResult(Activity.RESULT_OK, intent)
+    }
+
+    private fun Map<String, Any>.toBundle(): Bundle {
+        val bundle = Bundle()
+        forEach { (key, value) ->
+            when (value) {
+                is String -> bundle.putString(key, value)
+                is Int -> bundle.putInt(key, value)
+                is Long -> bundle.putLong(key, value)
+                is Boolean -> bundle.putBoolean(key, value)
+                is Float -> bundle.putFloat(key, value)
+                is Double -> bundle.putDouble(key, value)
+                is Parcelable -> bundle.putParcelable(key, value)
+                is Serializable -> bundle.putSerializable(key, value)
+                else -> throw IllegalArgumentException("Unsupported type of '${value::class.java}'.")
+            }
+        }
+        return bundle
+    }
+}

--- a/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityResultSettingEventSinkTest.kt
+++ b/lib-kmm-foundation/src/androidTest/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityResultSettingEventSinkTest.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.activity
+
+import android.app.Activity
+import android.os.Parcel
+import android.os.Parcelable
+import androidx.activity.ComponentActivity
+import androidx.test.runner.AndroidJUnit4
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.presentation.Adapter
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.Shadows
+import java.io.Serializable
+
+@RunWith(AndroidJUnit4::class)
+class ActivityResultSettingEventSinkTest {
+
+    private val activityController = Robolectric.buildActivity(ComponentActivity::class.java)
+    private val activity = activityController.get()
+    private val shadowActivity = Shadows.shadowOf(activity)
+    private val adapter = Adapter<Event, Map<String, Any>> { event ->
+        if (event is SelectionEvent) {
+            mapOf(
+                "str" to "foobar",
+                "int" to 42,
+                "bol" to true,
+                "flt" to 3.14f,
+                "dbl" to 3.14,
+                "lng" to 42L,
+                "prc" to FakeParcelable("foobar"),
+                "srz" to FakeSerializable("foobar")
+            )
+        } else {
+            emptyMap()
+        }
+    }
+    private val eventSink = ActivityResultSettingEventSink(activity, adapter)
+
+    @Before
+    fun `Starts activity`() {
+        activityController.setup().visible()
+    }
+
+    @Test
+    fun `Sets RESULT_OK as the activity result upon receiving a non-empty value set`() {
+        eventSink.sink(SelectionEvent("foo", "bar"))
+
+        shadowActivity.resultCode.shouldBe(Activity.RESULT_OK)
+        shadowActivity.resultIntent.extras?.let { bundle ->
+            bundle.getString("str").shouldBe("foobar")
+            bundle.getInt("int").shouldBe(42)
+            bundle.getBoolean("bol").shouldBe(true)
+            bundle.getFloat("flt").shouldBe(3.14f)
+            bundle.getDouble("dbl").shouldBe(3.14)
+            bundle.getLong("lng").shouldBe(42L)
+            bundle.getParcelable<FakeParcelable>("prc").let { prc ->
+                prc.shouldBeInstanceOf<FakeParcelable>()
+                prc.value.shouldBe("foobar")
+            }
+            bundle.getSerializable("srz")!!.let { srz ->
+                srz.shouldBeInstanceOf<FakeSerializable>()
+                srz.value.shouldBe("foobar")
+            }
+        }
+    }
+
+    @Test
+    fun `Sets RESULT_CANCELED as the activity result upon receiving an empty value set`() {
+        eventSink.sink(CompletionEvent())
+
+        shadowActivity.resultCode.shouldBe(Activity.RESULT_CANCELED)
+        shadowActivity.resultIntent.shouldBeNull()
+    }
+
+    @Test
+    fun `Throws upon receiving a non-empty value set with unknown type`() {
+        val badAdapter = Adapter<Event, Map<String, Any>> { event ->
+            if (event is SelectionEvent) {
+                mapOf("foo" to FakeNonSerializableNorParcelable())
+            } else {
+                emptyMap()
+            }
+        }
+        val eventSink = ActivityResultSettingEventSink(activity, badAdapter)
+
+        shouldThrow<IllegalArgumentException> {
+            eventSink.sink(SelectionEvent("foo", "bar"))
+        }
+    }
+
+    private class FakeParcelable(val value: String) : Parcelable {
+
+        constructor(parcel: Parcel) : this(parcel.readString()!!)
+
+        override fun writeToParcel(parcel: Parcel, flags: Int) {
+            parcel.writeString(value)
+        }
+
+        override fun describeContents(): Int {
+            return 0
+        }
+
+        companion object CREATOR : Parcelable.Creator<FakeParcelable> {
+
+            override fun createFromParcel(parcel: Parcel): FakeParcelable {
+                return FakeParcelable(parcel)
+            }
+
+            override fun newArray(size: Int): Array<FakeParcelable?> {
+                return arrayOfNulls(size)
+            }
+        }
+    }
+
+    @Suppress("SerialVersionUIDInSerializableClass")
+    private class FakeSerializable(val value: String) : Serializable
+
+    private class FakeNonSerializableNorParcelable
+}


### PR DESCRIPTION
### What has changed

We have replaced the dependency on a global `EventHub` for facilitating cross-activity interaction with the Activity Results API, which handles state restoration out-of-the-box. The new approach closely follows the flow we have been using for media selection and capture, where the activity responsible for providing the result (i.e., the responder) is treated as an implementation detail of its corresponding `EventSource`.

### Why it was changed

The previous behavior, introduced in #14, initially seemed to work well. However, during actual usage of the application, an issue was encountered. In one instance, when I kept the place selection screen open for a brief period and then returned to the moment editor screen, I noticed that the selected place was not properly reflected in the editor.

It was quite obvious that this has something to do with state restoration. The previous behavior worked on the premise that the requester `UseCase` (and therefore its hosting activity) remains available to handle the event emitted by the responder–a clear mistake in hindsight.