### PR TITLE
Fix unexpected activity finish on configuration change

### DIFF
--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityCompletionEventSink.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityCompletionEventSink.kt
@@ -28,6 +28,7 @@ class ActivityCompletionEventSink(
 
     override fun sink(event: Event) {
         if (event !is CompletionEvent) return
+        if (activity.isFinishing || activity.isChangingConfigurations) return
         activity.finish()
     }
 }


### PR DESCRIPTION
### What has changed

`ActivityCompletionEventSink` now checks for `isFinishing` and `isChangingConfigurations` before calling `Activity#finish()`.

### Why it was changed

It seems like `Activity#finish()` would "persist" across configuration change. Meaning, if we call `finish()` on Activity A1 while it's being destroyed and replaced by Activity A2 because of configuration change, A2 will end up affected by the request.