### PR TITLE
Surface moment-based reflections

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
@@ -39,6 +39,7 @@ class ActivityRoutingEventSink(
         val identifier = event.selectedIdentifier
         val activity = currentActivity.acquire()
         when (identifier) {
+            "view_reflections" -> activity.startViewReflectionsActivity()
             "add_story" -> activity.startActivity(Intent(activity, EditAStoryActivity::class.java))
             "edit_story" -> activity.startEditAStoryActivity(event)
             "delete_story" -> activity.startDeleteAStoryActivity(event)
@@ -49,6 +50,12 @@ class ActivityRoutingEventSink(
             "delete_moment" -> activity.startDeleteAMomentActivity(event)
             "select_place" -> activity.startActivity(Intent(activity, SelectAPlaceActivity::class.java))
         }
+    }
+
+    private fun Activity.startViewReflectionsActivity() {
+        val intent = Intent(this, RootActivity::class.java)
+        intent.setAction("view_reflections")
+        startActivity(intent)
     }
 
     private fun Activity.startViewStoriesActivity() {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -34,6 +34,7 @@ import kotlin.time.Duration
 abstract class Journal3Application : Application() {
     abstract val places: Places
     abstract val stories: Stories
+    abstract val reflections: Stories
     abstract val modalPresenter: Presenter<Modal>
     abstract val currentActivity: CurrentActivity
     abstract val globalEventSink: EventSink

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.apps.android.journal3
 
 import androidx.core.content.ContextCompat
 import com.google.android.material.color.DynamicColors
-import com.hadisatrio.apps.kotlin.journal3.moment.MemorablesCollection
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorableFiles
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorablePlaces
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMentionedPeople
@@ -70,7 +70,7 @@ class RealJournal3Application : Journal3Application() {
         FilesystemStories(
             fileSystem = FileSystem.SYSTEM,
             path = filesDir.absolutePath.toPath() / "content" / "stories",
-            memorables = MemorablesCollection(
+            memorables = MergedMemorables(
                 FilesystemMemorablePlaces(
                     fileSystem = FileSystem.SYSTEM,
                     path = filesDir.absolutePath.toPath() / "content" / "places",

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -23,8 +23,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.navigation.NavigationBarView
-import com.hadisatrio.apps.android.journal3.story.ReflectionsListFragment
-import com.hadisatrio.apps.android.journal3.story.StoriesListFragment
+import com.hadisatrio.apps.android.journal3.story.ReflectionStoriesListFragment
+import com.hadisatrio.apps.android.journal3.story.UserStoriesListFragment
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.NavigationBarSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
@@ -101,8 +101,8 @@ class RootActivity : AppCompatActivity() {
         pager.isUserInputEnabled = false
         pager.adapter = SimpleFragmentPagerAdapter(
             activity = this,
-            FragmentFactory { ReflectionsListFragment() },
-            FragmentFactory { StoriesListFragment() }
+            FragmentFactory { ReflectionStoriesListFragment() },
+            FragmentFactory { UserStoriesListFragment() }
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.navigation.NavigationBarView
+import com.hadisatrio.apps.android.journal3.story.ReflectionsListFragment
 import com.hadisatrio.apps.android.journal3.story.StoriesListFragment
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.NavigationBarSelectionEventSource
@@ -64,7 +65,16 @@ class RootActivity : AppCompatActivity() {
                 ),
                 NavigationBarSelectionEventSource(
                     view = bottomBar,
-                    eventFactory = { SelectionEvent("action", "view_stories") }
+                    eventFactory = { itemId ->
+                        SelectionEvent(
+                            "action",
+                            when (itemId) {
+                                R.id.view_reflections_menu_item -> "view_reflections"
+                                R.id.view_stories_menu_item -> "view_stories"
+                                else -> throw IllegalArgumentException("Unknown menu ID of \"$itemId\".")
+                            }
+                        )
+                    }
                 )
             )
         )
@@ -89,13 +99,18 @@ class RootActivity : AppCompatActivity() {
     private fun setupViews() {
         setContentView(R.layout.activity_root)
         pager.isUserInputEnabled = false
-        pager.adapter = SimpleFragmentPagerAdapter(this, FragmentFactory { StoriesListFragment() })
+        pager.adapter = SimpleFragmentPagerAdapter(
+            activity = this,
+            FragmentFactory { ReflectionsListFragment() },
+            FragmentFactory { StoriesListFragment() }
+        )
     }
 
     override fun onNewIntent(intent: Intent?) {
         super.onNewIntent(intent)
         val (menuId, pagerItem) = when (intent?.action) {
-            "view_stories" -> R.id.view_stories_menu_item to 0
+            "view_reflections" -> R.id.view_reflections_menu_item to 0
+            "view_stories" -> R.id.view_stories_menu_item to 1
             else -> return
         }
         if (bottomBar.selectedItemId != menuId) bottomBar.selectedItemId = menuId

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -18,13 +18,8 @@
 package com.hadisatrio.apps.android.journal3.story
 
 import android.content.res.Resources
-import android.graphics.Rect
-import android.os.Bundle
 import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 import android.widget.TextView
-import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -34,20 +29,14 @@ import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
-import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
 import com.hadisatrio.libs.android.dimensions.GOLDEN_RATIO
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
-import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
-import com.hadisatrio.libs.kotlin.foundation.event.EventSink
-import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
@@ -56,13 +45,9 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPre
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlin.math.roundToInt
 
-class ReflectionsListFragment : Fragment() {
+class ReflectionStoriesListFragment : StoriesListFragment() {
 
-    private val storiesListView: RecyclerView by lazy {
-        requireView().findViewById(R.id.stories_list)
-    }
-
-    private val presenter: Presenter<Stories> by lazy {
+    override val presenter: Presenter<Stories> by lazy {
         val subItemViewFactory = RecyclerViewPresenter.ViewFactory { parent, _ ->
             val inflater = LayoutInflater.from(parent.context)
             val view = inflater.inflate(R.layout.view_moment_snippet_card, parent, false)
@@ -117,7 +102,7 @@ class ReflectionsListFragment : Fragment() {
         )
     }
 
-    private val eventSource: EventSource by lazy {
+    override val eventSource: EventSource by lazy {
         ExecutorDispatchingEventSource(
             executor = journal3Application.foregroundExecutor,
             origin = EventSources(
@@ -131,46 +116,6 @@ class ReflectionsListFragment : Fragment() {
                     lifecycleOwner = this,
                     lifecycleEvent = Lifecycle.Event.ON_DESTROY,
                     eventFactory = { CancellationEvent("system") }
-                )
-            )
-        )
-    }
-
-    private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityCompletionEventSink(requireActivity())
-        )
-    }
-
-    private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = ShowStoriesUseCase(
-                stories = journal3Application.reflections,
-                presenter = presenter,
-                eventSource = eventSource,
-                eventSink = eventSink
-            )
-        )
-    }
-
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_view_stories, container, false)
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        setupViews()
-        useCase()
-    }
-
-    private fun setupViews() {
-        storiesListView.addItemDecoration(
-            SpacingItemDecoration(
-                Spacing(
-                    edges = Rect(16.dp, 16.dp, 16.dp, 16.dp),
-                    horizontal = 16.dp,
-                    vertical = 16.dp
                 )
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionsListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionsListFragment.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.story
+
+import android.content.res.Resources
+import android.graphics.Rect
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.grzegorzojdana.spacingitemdecoration.Spacing
+import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
+import com.hadisatrio.apps.android.journal3.R
+import com.hadisatrio.apps.android.journal3.journal3Application
+import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
+import com.hadisatrio.apps.kotlin.journal3.story.Stories
+import com.hadisatrio.apps.kotlin.journal3.story.Story
+import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
+import com.hadisatrio.libs.android.dimensions.GOLDEN_RATIO
+import com.hadisatrio.libs.android.dimensions.dp
+import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
+import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
+import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
+import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
+import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import kotlin.math.roundToInt
+
+class ReflectionsListFragment : Fragment() {
+
+    private val storiesListView: RecyclerView by lazy {
+        requireView().findViewById(R.id.stories_list)
+    }
+
+    private val presenter: Presenter<Stories> by lazy {
+        val subItemViewFactory = RecyclerViewPresenter.ViewFactory { parent, _ ->
+            val inflater = LayoutInflater.from(parent.context)
+            val view = inflater.inflate(R.layout.view_moment_snippet_card, parent, false)
+            val width = (Resources.getSystem().displayMetrics.widthPixels / GOLDEN_RATIO).roundToInt()
+            val height = (width * GOLDEN_RATIO).roundToInt()
+            view.layoutParams = RecyclerView.LayoutParams(width, height)
+            view
+        }
+        val subItemViewRenderer = RecyclerViewPresenter.ViewRenderer<Moment> { view, item ->
+            view.findViewById<TextView>(R.id.date_and_place_label).text =
+                "${item.timestamp} at ${item.place.name}"
+            view.findViewById<TextView>(R.id.description_label).text =
+                item.description.toString()
+            view.findViewById<TextView>(R.id.mood_and_attachment_count_label).text =
+                "${item.sentiment.value} · ${item.attachments.count()} attachment(s)"
+        }
+        val itemViewFactory = RecyclerViewPresenter.ViewFactory { parent, _ ->
+            val inflater = LayoutInflater.from(parent.context)
+            val view = inflater.inflate(R.layout.view_story_carousel, parent, false)
+            val carousel = view.findViewById<RecyclerView>(R.id.moments_carousel)
+            val carouselPresenter = RecyclerViewPresenter(
+                recyclerView = carousel,
+                viewFactory = subItemViewFactory,
+                viewRenderer = subItemViewRenderer,
+                layoutManager = LinearLayoutManager(parent.context, LinearLayoutManager.HORIZONTAL, false)
+            )
+            carousel.addItemDecoration(SpacingItemDecoration(Spacing(horizontal = 8.dp)))
+            view.setTag(R.id.presenter_view_tag, carouselPresenter)
+            view
+        }
+        val itemViewRenderer = RecyclerViewPresenter.ViewRenderer<Story> { view, item ->
+            view.findViewById<TextView>(R.id.title_label).text = item.title
+            view.findViewById<TextView>(R.id.synopsis_label).text = item.synopsis.toString()
+            (view.getTag(R.id.presenter_view_tag) as RecyclerViewPresenter<Moment>).present(item.moments)
+        }
+
+        ExecutorDispatchingPresenter(
+            executor = journal3Application.backgroundExecutor,
+            origin = CachingStoriesPresenter(
+                origin = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = AdaptingPresenter(
+                        adapter = { stories -> stories.toList() },
+                        origin = RecyclerViewPresenter(
+                            recyclerView = storiesListView,
+                            viewFactory = itemViewFactory,
+                            viewRenderer = itemViewRenderer
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    private val eventSource: EventSource by lazy {
+        ExecutorDispatchingEventSource(
+            executor = journal3Application.foregroundExecutor,
+            origin = EventSources(
+                journal3Application.globalEventSource,
+                LifecycleTriggeredEventSource(
+                    lifecycleOwner = this,
+                    lifecycleEvent = Lifecycle.Event.ON_START,
+                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                ),
+                LifecycleTriggeredEventSource(
+                    lifecycleOwner = this,
+                    lifecycleEvent = Lifecycle.Event.ON_DESTROY,
+                    eventFactory = { CancellationEvent("system") }
+                )
+            )
+        )
+    }
+
+    private val eventSink: EventSink by lazy {
+        EventSinks(
+            journal3Application.globalEventSink,
+            ActivityCompletionEventSink(requireActivity())
+        )
+    }
+
+    private val useCase: UseCase by lazy {
+        ExecutorDispatchingUseCase(
+            executor = journal3Application.backgroundExecutor,
+            origin = ShowStoriesUseCase(
+                stories = journal3Application.reflections,
+                presenter = presenter,
+                eventSource = eventSource,
+                eventSink = eventSink
+            )
+        )
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_view_stories, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupViews()
+        useCase()
+    }
+
+    private fun setupViews() {
+        storiesListView.addItemDecoration(
+            SpacingItemDecoration(
+                Spacing(
+                    edges = Rect(16.dp, 16.dp, 16.dp, 16.dp),
+                    horizontal = 16.dp,
+                    vertical = 16.dp
+                )
+            )
+        )
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
@@ -22,87 +22,32 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import com.grzegorzojdana.spacingitemdecoration.Spacing
 import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
-import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
-import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
 import com.hadisatrio.libs.android.dimensions.dp
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
-import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
-import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
-import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
-import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
-import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
-import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
-class StoriesListFragment : Fragment() {
+abstract class StoriesListFragment : Fragment() {
 
-    private val storiesListView: RecyclerView by lazy {
+    protected val storiesListView: RecyclerView by lazy {
         requireView().findViewById(R.id.stories_list)
     }
 
-    private val presenter: Presenter<Stories> by lazy {
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.backgroundExecutor,
-            origin = CachingStoriesPresenter(
-                origin = ExecutorDispatchingPresenter(
-                    executor = journal3Application.foregroundExecutor,
-                    origin = AdaptingPresenter(
-                        origin = RecyclerViewPresenter(
-                            recyclerView = storiesListView,
-                            viewFactory = { parent, _ ->
-                                LayoutInflater.from(parent.context)
-                                    .inflate(R.layout.view_story_snippet_card, parent, false)
-                            },
-                            viewRenderer = { view, item ->
-                                view.findViewById<TextView>(R.id.title_label).text = item.title
-                                view.findViewById<TextView>(R.id.synopsis_label).text = item.synopsis.toString()
-                            }
-                        ),
-                        adapter = { stories -> stories.toList() }
-                    )
-                )
-            )
-        )
-    }
+    abstract val presenter: Presenter<Stories>
 
-    private val eventSource: EventSource by lazy {
-        ExecutorDispatchingEventSource(
-            executor = journal3Application.foregroundExecutor,
-            origin = EventSources(
-                journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_START,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
-                ),
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_DESTROY,
-                    eventFactory = { CancellationEvent("system") }
-                ),
-                RecyclerViewItemSelectionEventSource(
-                    recyclerView = storiesListView
-                )
-            )
-        )
-    }
+    abstract val eventSource: EventSource
 
     private val eventSink: EventSink by lazy {
         EventSinks(
@@ -115,7 +60,7 @@ class StoriesListFragment : Fragment() {
         ExecutorDispatchingUseCase(
             executor = journal3Application.backgroundExecutor,
             origin = ShowStoriesUseCase(
-                stories = journal3Application.stories,
+                stories = journal3Application.reflections,
                 presenter = presenter,
                 eventSource = eventSource,
                 eventSink = eventSink
@@ -123,11 +68,15 @@ class StoriesListFragment : Fragment() {
         )
     }
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    final override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.fragment_view_stories, container, false)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    final override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         setupViews()
         useCase()
     }
@@ -138,7 +87,7 @@ class StoriesListFragment : Fragment() {
                 Spacing(
                     edges = Rect(16.dp, 16.dp, 16.dp, 16.dp),
                     horizontal = 16.dp,
-                    vertical = 8.dp
+                    vertical = 16.dp
                 )
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.story
+
+import android.view.LayoutInflater
+import android.widget.TextView
+import androidx.lifecycle.Lifecycle
+import com.hadisatrio.apps.android.journal3.R
+import com.hadisatrio.apps.android.journal3.journal3Application
+import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
+import com.hadisatrio.apps.kotlin.journal3.story.Stories
+import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
+import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
+import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.event.ExecutorDispatchingEventSource
+import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
+import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+
+class UserStoriesListFragment : StoriesListFragment() {
+
+    override val presenter: Presenter<Stories> by lazy {
+        ExecutorDispatchingPresenter(
+            executor = journal3Application.backgroundExecutor,
+            origin = CachingStoriesPresenter(
+                origin = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = AdaptingPresenter(
+                        origin = RecyclerViewPresenter(
+                            recyclerView = storiesListView,
+                            viewFactory = { parent, _ ->
+                                LayoutInflater.from(parent.context)
+                                    .inflate(R.layout.view_story_snippet_card, parent, false)
+                            },
+                            viewRenderer = { view, item ->
+                                view.findViewById<TextView>(R.id.title_label).text = item.title
+                                view.findViewById<TextView>(R.id.synopsis_label).text = item.synopsis.toString()
+                            }
+                        ),
+                        adapter = { stories -> stories.toList() }
+                    )
+                )
+            )
+        )
+    }
+
+    override val eventSource: EventSource by lazy {
+        ExecutorDispatchingEventSource(
+            executor = journal3Application.foregroundExecutor,
+            origin = EventSources(
+                journal3Application.globalEventSource,
+                LifecycleTriggeredEventSource(
+                    lifecycleOwner = this,
+                    lifecycleEvent = Lifecycle.Event.ON_START,
+                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                ),
+                LifecycleTriggeredEventSource(
+                    lifecycleOwner = this,
+                    lifecycleEvent = Lifecycle.Event.ON_DESTROY,
+                    eventFactory = { CancellationEvent("system") }
+                ),
+                RecyclerViewItemSelectionEventSource(
+                    recyclerView = storiesListView
+                )
+            )
+        )
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/dimensions/GoldenRatio.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/dimensions/GoldenRatio.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.dimensions
+
+const val GOLDEN_RATIO = 1.618

--- a/app-android-journal3/src/main/res/drawable/ic_reflections.xml
+++ b/app-android-journal3/src/main/res/drawable/ic_reflections.xml
@@ -1,0 +1,33 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,6m-2,0a2,2 0,1 1,4 0a2,2 0,1 1,-4 0" />
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,16v-2c-2.24,0 -4.16,-0.96 -5.6,-2.68l-1.34,-1.6C13.68,9.26 13.12,9 12.53,9h-1.05c-0.59,0 -1.15,0.26 -1.53,0.72l-1.34,1.6C7.16,13.04 5.24,14 3,14v2c2.77,0 5.19,-1.17 7,-3.25V15l-3.88,1.55C5.45,16.82 5,17.48 5,18.21C5,19.2 5.8,20 6.79,20H9v-0.5c0,-1.38 1.12,-2.5 2.5,-2.5h3c0.28,0 0.5,0.22 0.5,0.5S14.78,18 14.5,18h-3c-0.83,0 -1.5,0.67 -1.5,1.5V20h7.21C18.2,20 19,19.2 19,18.21c0,-0.73 -0.45,-1.39 -1.12,-1.66L14,15v-2.25C15.81,14.83 18.23,16 21,16z" />
+
+</vector>

--- a/app-android-journal3/src/main/res/layout/view_story_carousel.xml
+++ b/app-android-journal3/src/main/res/layout/view_story_carousel.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:checkable="true"
+    android:clickable="true"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/title_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/TextAppearance.Material3.HeadlineSmall"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="@tools:sample/lorem" />
+
+    <TextView
+        android:id="@+id/synopsis_label"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:maxLines="3"
+        android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+        app:layout_constraintEnd_toEndOf="@id/title_label"
+        app:layout_constraintStart_toStartOf="@id/title_label"
+        app:layout_constraintTop_toBottomOf="@id/title_label"
+        tools:text="@tools:sample/lorem" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/moments_carousel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/gutter"
+        app:layout_constraintEnd_toEndOf="@id/title_label"
+        app:layout_constraintStart_toStartOf="@id/title_label"
+        app:layout_constraintTop_toBottomOf="@id/synopsis_label" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app-android-journal3/src/main/res/values/ids.xml
+++ b/app-android-journal3/src/main/res/values/ids.xml
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
   ~ Copyright (C) 2022 Hadi Satrio
   ~
   ~ This program is free software: you can redistribute it and/or modify
@@ -15,18 +17,6 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
-
-    <item
-        android:id="@+id/view_reflections_menu_item"
-        android:enabled="true"
-        android:icon="@drawable/ic_reflections"
-        android:title="Reflections" />
-
-    <item
-        android:id="@+id/view_stories_menu_item"
-        android:enabled="true"
-        android:icon="@drawable/ic_stories"
-        android:title="Stories" />
-
-</menu>
+<resources>
+    <item name="presenter_view_tag" type="id" />
+</resources>

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -43,6 +43,7 @@ class FakeJournal3Application : Journal3Application() {
 
     override val places: Places by lazy { SelfPopulatingPlaces(10, FakePlaces()) }
     override val stories: Stories by lazy { SelfPopulatingStories(10, 10, FakeStories()) }
+    override val reflections: Stories by lazy { FakeStories() }
     override val modalPresenter: Presenter<Modal> by lazy { FakePresenter() }
     override val currentActivity: CurrentActivity by lazy { CurrentActivity(this) }
     override val globalEventSink: EventSink by lazy { FakeEventSink() }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMoments.kt
@@ -15,32 +15,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.sentiment
+package com.hadisatrio.apps.kotlin.journal3.moment
 
-import kotlin.jvm.JvmInline
+import com.benasher44.uuid.Uuid
 
-@JvmInline
-value class Sentiment(val value: Float) : Comparable<Sentiment> {
+class CountLimitingMoments(
+    private val limit: Int,
+    private val origin: Moments
+) : Moments {
 
-    constructor(value: String) : this(value.toFloat())
-
-    constructor(others: Iterable<Sentiment>) : this(others.map { it.value }.average().toFloat())
-
-    init {
-        require(value in 0.0F..1.0F) {
-            "Sentiment value must be between 0.0 and 1.0; given was $value."
-        }
+    override fun count(): Int {
+        return toList().size
     }
 
-    override fun toString(): String {
-        return value.toString()
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
     }
 
-    override fun compareTo(other: Sentiment): Int {
-        return value.compareTo(other.value)
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
     }
 
-    companion object {
-        val DEFAULT = Sentiment(0.123456789F)
+    override fun iterator(): Iterator<Moment> {
+        return origin.asSequence().take(limit).iterator()
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -23,9 +23,9 @@ import com.chrynan.uri.core.fromString
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.id.TargetId
-import com.hadisatrio.apps.kotlin.journal3.moment.datetime.ClockRespectingMoments
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
+import com.hadisatrio.apps.kotlin.journal3.story.datetime.ClockRespectingStory
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
@@ -80,9 +80,9 @@ class EditAMomentUseCase(
                 stories.findMoment(targetId.asUuid()).first()
             } else {
                 val story = stories.findStory(storyId.asUuid()).first()
-                val moments = ClockRespectingMoments(clock, story.moments)
+                val clockRespecting = ClockRespectingStory(clock, story)
                 isTargetNew = true
-                moments.new()
+                clockRespecting.new()
             }
         )
     }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -24,6 +24,7 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.id.TargetId
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.datetime.ClockRespectingStory
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
@@ -79,7 +80,7 @@ class EditAMomentUseCase(
             if (targetId.isValid()) {
                 stories.findMoment(targetId.asUuid()).first()
             } else {
-                val story = stories.findStory(storyId.asUuid()).first()
+                val story = stories.findStory(storyId.asUuid()).first() as EditableStory
                 val clockRespecting = ClockRespectingStory(clock, story)
                 isTargetNew = true
                 clockRespecting.new()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorables.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorables.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
-class MemorablesCollection(
+class MergedMemorables(
     private val collection: Iterable<Memorables>
 ) : Memorables {
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
@@ -23,10 +23,6 @@ class MergedMoments(private val moments: Iterable<Moments>) : Moments {
 
     constructor(vararg moments: Moments) : this(moments.toList())
 
-    override fun new(): Moment {
-        return moments.first().new()
-    }
-
     override fun count(): Int {
         return toList().size
     }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
@@ -15,26 +15,31 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.story
+package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
-import com.hadisatrio.apps.kotlin.journal3.moment.Moment
-import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 
-interface Stories : Iterable<Story> {
-    val moments: Moments
+class MergedMoments(private val moments: Iterable<Moments>) : Moments {
 
-    fun new(): Story
+    constructor(vararg moments: Moments) : this(moments.toList())
 
-    fun containsStory(id: Uuid): Boolean
+    override fun new(): Moment {
+        return moments.first().new()
+    }
 
-    fun findStory(id: Uuid): Iterable<Story>
+    override fun count(): Int {
+        return toList().size
+    }
 
-    fun hasMoments(): Boolean
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
+    }
 
-    fun containsMoment(id: Uuid): Boolean
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
+    }
 
-    fun findMoment(id: Uuid): Iterable<Moment>
-
-    fun mostRecentMoment(): Moment
+    override fun iterator(): Iterator<Moment> {
+        return moments.flatten().iterator()
+    }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
@@ -20,7 +20,6 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.benasher44.uuid.Uuid
 
 interface Moments : Iterable<Moment> {
-    fun new(): Moment
 
     fun count(): Int
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMoments.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import kotlin.random.Random
+
+class OrderRandomizingMoments(
+    private val random: Random,
+    private val origin: Moments
+) : Moments by origin {
+
+    constructor(origin: Moments) : this(Random, origin)
+
+    override fun iterator(): Iterator<Moment> {
+        return origin.asSequence().shuffled(random).iterator()
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMoments.kt
@@ -15,32 +15,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.sentiment
+package com.hadisatrio.apps.kotlin.journal3.moment
 
-import kotlin.jvm.JvmInline
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 
-@JvmInline
-value class Sentiment(val value: Float) : Comparable<Sentiment> {
+class SentimentRangedMoments(
+    private val sentimentRange: ClosedRange<Sentiment>,
+    private val origin: Moments
+) : Moments {
 
-    constructor(value: String) : this(value.toFloat())
-
-    constructor(others: Iterable<Sentiment>) : this(others.map { it.value }.average().toFloat())
-
-    init {
-        require(value in 0.0F..1.0F) {
-            "Sentiment value must be between 0.0 and 1.0; given was $value."
-        }
+    override fun count(): Int {
+        return toList().size
     }
 
-    override fun toString(): String {
-        return value.toString()
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
     }
 
-    override fun compareTo(other: Sentiment): Int {
-        return value.compareTo(other.value)
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
     }
 
-    companion object {
-        val DEFAULT = Sentiment(0.123456789F)
+    override fun iterator(): Iterator<Moment> {
+        val moments = origin.asSequence().filter { it.sentiment in sentimentRange }
+        return moments.iterator()
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMoments.kt
@@ -15,32 +15,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.sentiment
+package com.hadisatrio.apps.kotlin.journal3.moment
 
-import kotlin.jvm.JvmInline
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 
-@JvmInline
-value class Sentiment(val value: Float) : Comparable<Sentiment> {
+class TimeRangedMoments(
+    private val timeRange: ClosedRange<Timestamp>,
+    private val origin: Moments
+) : Moments {
 
-    constructor(value: String) : this(value.toFloat())
-
-    constructor(others: Iterable<Sentiment>) : this(others.map { it.value }.average().toFloat())
-
-    init {
-        require(value in 0.0F..1.0F) {
-            "Sentiment value must be between 0.0 and 1.0; given was $value."
-        }
+    override fun count(): Int {
+        return toList().size
     }
 
-    override fun toString(): String {
-        return value.toString()
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
     }
 
-    override fun compareTo(other: Sentiment): Int {
-        return value.compareTo(other.value)
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
     }
 
-    companion object {
-        val DEFAULT = Sentiment(0.123456789F)
+    override fun iterator(): Iterator<Moment> {
+        val moments = origin.asSequence().filter { it.timestamp in timeRange }
+        return moments.iterator()
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.libs.kotlin.geography.Coordinates
+import com.hadisatrio.libs.kotlin.geography.NullIsland
+
+class VicinityMoments(
+    private val coordinates: Coordinates,
+    private val distanceLimitInM: Double,
+    private val origin: Moments
+) : Moments {
+
+    override fun count(): Int {
+        return toList().size
+    }
+
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
+    }
+
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
+    }
+
+    override fun iterator(): Iterator<Moment> {
+        val hasPlace = origin.asSequence().filterNot { it.place is NullIsland }
+        val nearby = hasPlace.filter { it.place.distanceTo(coordinates).value <= distanceLimitInM }
+        return nearby.iterator()
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/fake/FakeMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/fake/FakeMoments.kt
@@ -18,7 +18,6 @@
 package com.hadisatrio.apps.kotlin.journal3.moment.fake
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 
@@ -27,12 +26,6 @@ class FakeMoments(
 ) : Moments {
 
     constructor(vararg moment: Moment) : this(moment.toMutableList())
-
-    override fun new(): Moment {
-        val moment = FakeMoment(uuid4(), moments)
-        moments.add(moment)
-        return moment
-    }
 
     override fun count(): Int {
         return moments.size

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -18,7 +18,6 @@
 package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.moment.Memorables
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
@@ -30,11 +29,6 @@ class FilesystemMoments(
     private val path: Path,
     private val memorables: Memorables
 ) : Moments {
-
-    override fun new(): Moment {
-        fileSystem.createDirectories(dir = path, mustCreate = false)
-        return FilesystemMoment(fileSystem, path, uuid4(), memorables)
-    }
 
     override fun count(): Int {
         return if (fileSystem.exists(path).not()) 0 else fileSystem.list(path).size

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentRanges.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentRanges.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("MagicNumber")
+
+package com.hadisatrio.apps.kotlin.journal3.sentiment
+
+object VeryPositiveSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(1.0F)
+    override val start: Sentiment = Sentiment(0.81F)
+}
+
+object PositiveSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(0.80F)
+    override val start: Sentiment = Sentiment(0.56F)
+}
+
+object NeutralSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(0.55F)
+    override val start: Sentiment = Sentiment(0.45F)
+}
+
+object NegativeSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(0.44F)
+    override val start: Sentiment = Sentiment(0.20F)
+}
+
+object VeryNegativeSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(0.19F)
+    override val start: Sentiment = Sentiment(0.0F)
+}
+
+object PositiveishSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(1.0F)
+    override val start: Sentiment = Sentiment(0.61F)
+}
+
+object NegativeishSentimentRange : ClosedRange<Sentiment> {
+    override val endInclusive: Sentiment = Sentiment(0.39F)
+    override val start: Sentiment = Sentiment(0.0F)
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/DeleteStoryUseCase.kt
@@ -34,6 +34,6 @@ class DeleteStoryUseCase(
 ) : DeleteForgettableUseCase(presenter, eventSource, eventSink) {
 
     override fun forgettable(): Forgettable? {
-        return stories.findStory(targetId.asUuid()).firstOrNull()
+        return stories.findStory(targetId.asUuid()).firstOrNull() as? EditableStory
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCase.kt
@@ -62,7 +62,7 @@ class EditAStoryUseCase(
     private fun identifyTarget() {
         currentTarget = UpdateDeferringStory(
             if (targetId.isValid()) {
-                stories.findStory(targetId.asUuid()).first()
+                stories.findStory(targetId.asUuid()).first() as EditableStory
             } else {
                 isTargetNew = true
                 stories.new()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditableStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditableStory.kt
@@ -17,24 +17,12 @@
 
 package com.hadisatrio.apps.kotlin.journal3.story
 
-import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.forgettable.Forgettable
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
-import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
-interface Stories : Iterable<Story> {
-    val moments: Moments
-
-    fun new(): EditableStory
-
-    fun containsStory(id: Uuid): Boolean
-
-    fun findStory(id: Uuid): Iterable<Story>
-
-    fun hasMoments(): Boolean
-
-    fun containsMoment(id: Uuid): Boolean
-
-    fun findMoment(id: Uuid): Iterable<Moment>
-
-    fun mostRecentMoment(): Moment
+interface EditableStory : Story, Forgettable {
+    fun update(title: String)
+    fun update(synopsis: TokenableString)
+    fun new(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStories.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+class MomentfulStories(
+    private val origin: Stories
+) : Stories by origin {
+
+    override fun iterator(): Iterator<Story> {
+        val momentful = origin.asSequence().filter { it.moments.count() > 0 }
+        return momentful.iterator()
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Reflection.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Reflection.kt
@@ -15,32 +15,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.sentiment
+package com.hadisatrio.apps.kotlin.journal3.story
 
-import kotlin.jvm.JvmInline
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
-@JvmInline
-value class Sentiment(val value: Float) : Comparable<Sentiment> {
+class Reflection(
+    override val title: String,
+    override val synopsis: TokenableString,
+    override val moments: Moments
+) : Story {
 
-    constructor(value: String) : this(value.toFloat())
+    constructor(title: String, moments: Moments) : this(title, TokenableString.EMPTY, moments)
 
-    constructor(others: Iterable<Sentiment>) : this(others.map { it.value }.average().toFloat())
+    override val id: Uuid by lazy { Uuid.nameUUIDFromBytes(title.toByteArray()) }
 
-    init {
-        require(value in 0.0F..1.0F) {
-            "Sentiment value must be between 0.0 and 1.0; given was $value."
-        }
-    }
-
-    override fun toString(): String {
-        return value.toString()
-    }
-
-    override fun compareTo(other: Sentiment): Int {
-        return value.compareTo(other.value)
-    }
-
-    companion object {
-        val DEFAULT = Sentiment(0.123456789F)
+    override fun compareTo(other: Story): Int {
+        return title.compareTo(other.title)
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
@@ -36,7 +36,7 @@ class SelfPopulatingStories(
             update("Story #$rep")
             update(TokenableString("This is a story."))
             repeat(noOfMoments) { rep2 ->
-                moments.new().apply {
+                new().apply {
                     update(TokenableString("This is a moment (#$rep-$rep2)."))
                     update(Timestamp(Clock.System.now()))
                 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
@@ -19,6 +19,7 @@ package com.hadisatrio.apps.kotlin.journal3.story
 
 import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.forgettable.Forgettable
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
@@ -30,4 +31,5 @@ interface Story : Forgettable, Comparable<Story> {
 
     fun update(title: String)
     fun update(synopsis: TokenableString)
+    fun new(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
@@ -18,18 +18,12 @@
 package com.hadisatrio.apps.kotlin.journal3.story
 
 import com.benasher44.uuid.Uuid
-import com.hadisatrio.apps.kotlin.journal3.forgettable.Forgettable
-import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
-interface Story : Forgettable, Comparable<Story> {
+interface Story : Comparable<Story> {
     val id: Uuid
     val title: String
     val synopsis: TokenableString
     val moments: Moments
-
-    fun update(title: String)
-    fun update(synopsis: TokenableString)
-    fun new(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStory.kt
@@ -20,8 +20,8 @@ package com.hadisatrio.apps.kotlin.journal3.story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
 class UpdateDeferringStory(
-    private val origin: Story
-) : Story by origin {
+    private val origin: EditableStory
+) : EditableStory by origin {
 
     private var titleInEdit: String = origin.title
     private var synopsisInEdit: TokenableString = origin.synopsis

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
@@ -19,13 +19,13 @@ package com.hadisatrio.apps.kotlin.journal3.story.datetime
 
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
-import com.hadisatrio.apps.kotlin.journal3.story.Story
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import kotlinx.datetime.Clock
 
 class ClockRespectingStory(
     private val clock: Clock,
-    private val origin: Story
-) : Story by origin {
+    private val origin: EditableStory
+) : EditableStory by origin {
 
     override fun new(): Moment {
         val moment = origin.new()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
@@ -15,17 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.moment.datetime
+package com.hadisatrio.apps.kotlin.journal3.story.datetime
 
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
-import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.story.Story
 import kotlinx.datetime.Clock
 
-class ClockRespectingMoments(
+class ClockRespectingStory(
     private val clock: Clock,
-    private val origin: Moments
-) : Moments by origin {
+    private val origin: Story
+) : Story by origin {
 
     override fun new(): Moment {
         val moment = origin.new()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
@@ -22,6 +22,7 @@ import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 
@@ -33,7 +34,7 @@ class FakeStories(
 
     constructor(vararg stories: Story) : this(stories.toMutableList())
 
-    override fun new(): Story {
+    override fun new(): EditableStory {
         val story = FakeStory(uuid4(), stories)
         stories.add(story)
         return story

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStories.kt
@@ -19,13 +19,17 @@ package com.hadisatrio.apps.kotlin.journal3.story.fake
 
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 
 class FakeStories(
     private val stories: MutableList<Story>
 ) : Stories {
+
+    override val moments: Moments get() = MergedMoments(map { it.moments })
 
     constructor(vararg stories: Story) : this(stories.toMutableList())
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
@@ -23,13 +23,14 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
 class FakeStory(
     override val id: Uuid,
     private val group: MutableList<Story>
-) : Story {
+) : EditableStory {
 
     private var isForgotten: Boolean = false
     private val rawMoments: MutableList<Moment> = mutableListOf()

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/fake/FakeStory.kt
@@ -18,7 +18,10 @@
 package com.hadisatrio.apps.kotlin.journal3.story.fake
 
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuid4
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
@@ -29,12 +32,13 @@ class FakeStory(
 ) : Story {
 
     private var isForgotten: Boolean = false
+    private val rawMoments: MutableList<Moment> = mutableListOf()
 
     override var title: String = ""
         private set
     override var synopsis: TokenableString = TokenableString.EMPTY
         private set
-    override var moments: Moments = FakeMoments(mutableListOf())
+    override var moments: Moments = FakeMoments(rawMoments)
         private set
 
     override fun update(title: String) {
@@ -45,6 +49,12 @@ class FakeStory(
     override fun update(synopsis: TokenableString) {
         require(!isForgotten) { "This story has already been forgotten." }
         this.synopsis = synopsis
+    }
+
+    override fun new(): Moment {
+        val moment = FakeMoment(uuid4(), rawMoments)
+        rawMoments.add(moment)
+        return moment
     }
 
     override fun forget() {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -23,8 +23,8 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Memorables
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
-import com.hadisatrio.apps.kotlin.journal3.story.Story
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
@@ -43,7 +43,7 @@ class FilesystemStories(
         memorables: Memorables
     ) : this(fileSystem, path.toPath(), memorables)
 
-    override fun new(): Story {
+    override fun new(): EditableStory {
         fileSystem.createDirectories(dir = path, mustCreate = false)
         return FilesystemStory(fileSystem, path, uuid4(), memorables)
     }
@@ -52,7 +52,7 @@ class FilesystemStories(
         return findStory(id).count() > 0
     }
 
-    override fun findStory(id: Uuid): Iterable<Story> {
+    override fun findStory(id: Uuid): Iterable<EditableStory> {
         val candidatePath = path / id.toString()
         if (fileSystem.exists(candidatePath)) {
             return listOf(FilesystemStory(fileSystem, candidatePath, memorables))
@@ -82,7 +82,7 @@ class FilesystemStories(
         return recentMoments.maxBy { it.timestamp }
     }
 
-    override fun iterator(): Iterator<Story> {
+    override fun iterator(): Iterator<EditableStory> {
         fileSystem.createDirectories(dir = path, mustCreate = false)
         val paths = fileSystem.list(path).asSequence()
         val stories = paths.map { path -> FilesystemStory(fileSystem, path, memorables) }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStories.kt
@@ -20,7 +20,9 @@ package com.hadisatrio.apps.kotlin.journal3.story.filesystem
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.moment.Memorables
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import okio.FileSystem
@@ -32,6 +34,8 @@ class FilesystemStories(
     private val path: Path,
     private val memorables: Memorables
 ) : Stories {
+
+    override val moments: Moments get() = MergedMoments(map { it.moments })
 
     constructor(
         fileSystem: FileSystem,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
@@ -25,6 +25,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMoments
+import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.json.JsonFile
@@ -38,7 +39,7 @@ class FilesystemStory(
     private val detailsFile: JsonFile,
     private val momentsDirectory: Path,
     private val memorables: Memorables
-) : Story {
+) : EditableStory {
 
     override val id: Uuid get() {
         return uuidFrom(directory.name)

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStory.kt
@@ -18,9 +18,12 @@
 package com.hadisatrio.apps.kotlin.journal3.story.filesystem
 
 import com.benasher44.uuid.Uuid
+import com.benasher44.uuid.uuid4
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.kotlin.journal3.moment.Memorables
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMoments
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
@@ -75,6 +78,11 @@ class FilesystemStory(
     override fun update(synopsis: TokenableString) {
         fileSystem.createDirectories(dir = directory, mustCreate = false)
         detailsFile.put("synopsis", JsonPrimitive(synopsis.toString()))
+    }
+
+    override fun new(): Moment {
+        fileSystem.createDirectories(dir = momentsDirectory, mustCreate = false)
+        return FilesystemMoment(fileSystem, momentsDirectory, uuid4(), memorables)
     }
 
     override fun forget() {

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
@@ -40,7 +40,7 @@ class AlertInactivityUseCaseTest {
     private val presenter = mockk<Presenter<Modal>>(relaxed = true)
     private val stories = FakeStories()
     private val story = stories.new()
-    private val moment = story.moments.new()
+    private val moment = story.new()
     private val eventSink = mockk<EventSink>(relaxed = true)
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMomentsTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class CountLimitingMomentsTest {
+
+    private val origin: Moments = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, FakeStories()).moments
+    private val moments: CountLimitingMoments = CountLimitingMoments(limit = 3, origin)
+    private val originalIds: List<Uuid> = origin.map { it.id }.toList()
+    private val truncatedIds: List<Uuid> = moments.map { it.id }.toList()
+
+    @Test
+    fun `Truncate the number of moments according to the given limit`() {
+        moments.count().shouldBe(3)
+        truncatedIds.shouldHaveSize(3)
+        truncatedIds.forEachIndexed { index, id -> originalIds[index].shouldBeEqual(id) }
+    }
+
+    @Test
+    fun `Finds nothing when asked to look for moments that have been truncated`() {
+        originalIds.take(3).forEach { moments.find(it).shouldNotBeEmpty() }
+        originalIds.drop(3).forEach { moments.find(it).shouldBeEmpty() }
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorablesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorablesTest.kt
@@ -8,9 +8,9 @@ import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import org.junit.Test
 
-class MemorablesCollectionTest {
+class MergedMemorablesTest {
 
-    private val collection = MemorablesCollection(
+    private val collection = MergedMemorables(
         FakeMemorables("places"),
         FakeMemorables("people")
     )

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMomentsTest.kt
@@ -34,7 +34,7 @@ class MergedMomentsTest {
 
     @BeforeTest
     fun `Populate moments`() {
-        repeat(10) { firstStory.moments.new(); secondStory.moments.new() }
+        repeat(10) { firstStory.new(); secondStory.new() }
     }
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMomentsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.benasher44.uuid.uuid4
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.shouldBe
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class MergedMomentsTest {
+
+    private val firstStory = FakeStories().new()
+    private val secondStory = FakeStories().new()
+    private val merged = MergedMoments(firstStory.moments, secondStory.moments)
+
+    @BeforeTest
+    fun `Populate moments`() {
+        repeat(10) { firstStory.moments.new(); secondStory.moments.new() }
+    }
+
+    @Test
+    fun `Counts all moments in the merged collection`() {
+        merged.count().shouldBe(20)
+    }
+
+    @Test
+    fun `Finds moments in the merged collection`() {
+        val firstId = firstStory.moments.shuffled().first().id
+        val secondId = secondStory.moments.shuffled().first().id
+        val invalidId = uuid4()
+        merged.find(firstId).shouldNotBeEmpty()
+        merged.find(secondId).shouldNotBeEmpty()
+        merged.find(invalidId).shouldBeEmpty()
+    }
+
+    @Test
+    fun `Finds the most recent moment over the merged collection`() {
+        val mostRecent = (firstStory.moments + secondStory.moments).maxBy { it.timestamp }
+        merged.mostRecent().id.shouldBe(mostRecent.id)
+    }
+
+    @Test
+    fun `Iterates over all moments in the merged collection`() {
+        merged.shouldHaveSize(20)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMomentsTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.equals.shouldNotBeEqual
+import kotlin.test.Test
+
+class OrderRandomizingMomentsTest {
+
+    private val origin: Moments = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, FakeStories()).moments
+    private val moments: OrderRandomizingMoments = OrderRandomizingMoments(origin)
+
+    @Test
+    fun `Randomizes the order of origin moments`() {
+        val originalIds = origin.map { it.id }.toList()
+        val randomizedIds = moments.map { it.id }.toList()
+        originalIds.shouldNotBeEqual(randomizedIds)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMomentsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.sentiment.NegativeishSentimentRange
+import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
+import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class SentimentRangedMomentsTest {
+
+    private val origin: Moments = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, FakeStories()).moments
+    private val moments: SentimentRangedMoments = SentimentRangedMoments(NegativeishSentimentRange, origin)
+
+    @BeforeTest
+    fun `Init moments`() {
+        origin.forEachIndexed { index, moment ->
+            if (index % 2 == 0) {
+                moment.update(Sentiment(0.0F))
+            } else {
+                moment.update(Sentiment(1.0F))
+            }
+        }
+    }
+
+    @Test
+    fun `Filters out moments whose sentiment is out of range`() {
+        val sentimentalIds = moments.map { it.id }.toList()
+        sentimentalIds.forEach { id ->
+            val moment = origin.find(id).first()
+            (moment.sentiment in NegativeishSentimentRange).shouldBeTrue()
+        }
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMomentsTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.days
+
+class TimeRangedMomentsTest {
+
+    private val currentInstant: Instant = Clock.System.now()
+    private val origin: Moments = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, FakeStories()).moments
+    private val timeRange: ClosedRange<Timestamp> = Timestamp(currentInstant - 3.days)..Timestamp(currentInstant)
+    private val moments: TimeRangedMoments = TimeRangedMoments(timeRange, origin)
+
+    @BeforeTest
+    fun `Init moments`() {
+        origin.forEachIndexed { index, moment ->
+            moment.update(Timestamp(currentInstant - index.days))
+        }
+    }
+
+    @Test
+    fun `Filters out moments whose timestamp is out of range`() {
+        val sentimentalIds = moments.map { it.id }.toList()
+        sentimentalIds.forEach { id ->
+            val moment = origin.find(id).first()
+            (moment.timestamp in timeRange).shouldBeTrue()
+        }
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaceTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaceTest.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
-import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
+import com.benasher44.uuid.uuid4
 import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
 import io.kotest.matchers.booleans.shouldBeFalse
@@ -63,9 +63,9 @@ class FilesystemMemorablePlaceTest {
 
     @Test
     fun `Reports relevancy for moments`() {
-        val oneMomentId = FakeMoments().new().id
-        val otherMomentId = FakeMoments().new().id
-        val momentId = FakeMoments().new().id
+        val oneMomentId = uuid4()
+        val otherMomentId = uuid4()
+        val momentId = uuid4()
 
         memorablePlace.link(oneMomentId)
         memorablePlace.link(otherMomentId)

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlacesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlacesTest.kt
@@ -19,7 +19,6 @@ package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.moment.Memorable
-import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.booleans.shouldBeTrue
@@ -92,7 +91,7 @@ class FilesystemMemorablePlacesTest {
 
     @Test
     fun `Finds a place relevant to given moment`() {
-        val momentId = FakeMoments().new().id
+        val momentId = uuid4()
         val places = FilesystemMemorablePlaces(fileSystem, "content".toPath())
         repeat(10) { places.remember(FakePlace()) }
         val randomized = places.toList().random()
@@ -105,18 +104,18 @@ class FilesystemMemorablePlacesTest {
 
     @Test
     fun `Returns empty iterable when asked to find a place relevant to an unknown moment`() {
-        val momentId = FakeMoments().new().id
+        val momentId = uuid4()
         val places = FilesystemMemorablePlaces(fileSystem, "content".toPath())
         repeat(10) { places.remember(FakePlace()).link(momentId) }
 
-        val found = places.relevantTo(FakeMoments().new().id)
+        val found = places.relevantTo(uuid4())
 
         found.shouldBeEmpty()
     }
 
     @Test
     fun `Throws when asked to relate an unknown referable`() {
-        val momentId = FakeMoments().new().id
+        val momentId = uuid4()
         val places = FilesystemMemorablePlaces(fileSystem, "content".toPath())
 
         shouldThrow<IllegalArgumentException> { places.relate(momentId, mockk<Memorable>()) }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
@@ -18,7 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
-import com.hadisatrio.apps.kotlin.journal3.moment.MemorablesCollection
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.filesystem.FilesystemStories
 import com.hadisatrio.apps.kotlin.journal3.token.Token
@@ -53,7 +53,7 @@ class FilesystemMomentTest {
     private val people = FilesystemMentionedPeople(fileSystem, "content/people".toPath())
     private val sources = FileSystemSources(fileSystem)
     private val attachments = FilesystemMemorableFiles(sources, fileSystem, "content/attachments".toPath())
-    private val memorables = MemorablesCollection(places, people, attachments)
+    private val memorables = MergedMemorables(places, people, attachments)
     private val stories = FilesystemStories(fileSystem, "content".toPath(), memorables)
     private val story = stories.new()
     private val moments = story.moments

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
@@ -56,7 +56,6 @@ class FilesystemMomentTest {
     private val memorables = MergedMemorables(places, people, attachments)
     private val stories = FilesystemStories(fileSystem, "content".toPath(), memorables)
     private val story = stories.new()
-    private val moments = story.moments
 
     @AfterTest
     fun `Closes all file streams`() {
@@ -65,7 +64,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Returns expected default values`() {
-        val moment = moments.new()
+        val moment = story.new()
 
         moment.timestamp.shouldBe(Timestamp(Instant.fromEpochMilliseconds(0)))
         moment.description.shouldBe(TokenableString(""))
@@ -76,7 +75,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Writes details updates to the filesystem`() {
-        val moment = moments.new()
+        val moment = story.new()
 
         moment.update(timestamp = Timestamp(Instant.fromEpochMilliseconds(1000)))
         moment.update(description = TokenableString("Foo"))
@@ -93,7 +92,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Writes place updates to the filesystem`() {
-        val moment = moments.new()
+        val moment = story.new()
         val firstPlace = FakePlace()
         val secondPlace = FakePlace()
         val firstPlaceFileContent = {
@@ -131,7 +130,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Writes mention updates to the filesystem`() {
-        val moment = moments.new()
+        val moment = story.new()
         val person = people.remember(Token(("@nahlito")))
         val personFileContent = {
             val path = "content/people/${person.id}".toPath()
@@ -145,7 +144,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Write attachment updates to the filesystem`() {
-        val moment = moments.new()
+        val moment = story.new()
         val arbitraryExternalFilePath: Path by lazy {
             ("foo".toPath()).apply {
                 JsonFile(fileSystem, this).put("foo", JsonPrimitive("bar"))
@@ -160,7 +159,7 @@ class FilesystemMomentTest {
 
     @Test
     fun `Deletes itself from the filesystem`() {
-        val moment = moments.new()
+        val moment = story.new()
 
         moment.forget()
 
@@ -170,9 +169,9 @@ class FilesystemMomentTest {
 
     @Test
     fun `Compares itself to others based on timestamp`() {
-        val self = moments.new()
-        val newer = moments.new().apply { update(Timestamp(Instant.DISTANT_FUTURE)) }
-        val older = moments.new().apply { update(Timestamp(Instant.DISTANT_PAST)) }
+        val self = story.new()
+        val newer = story.new().apply { update(Timestamp(Instant.DISTANT_FUTURE)) }
+        val older = story.new().apply { update(Timestamp(Instant.DISTANT_PAST)) }
 
         self.compareTo(newer).shouldBeNegative()
         self.compareTo(older).shouldBePositive()

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
@@ -54,7 +54,7 @@ class FilesystemMomentsTest {
     @Test
     fun `Writes new moments to the filesystem`() {
         val story = stories.new()
-        val moment = story.moments.new()
+        val moment = story.new()
 
         moment.update(TokenableString("FizzBuzz"))
         moment.update(Sentiment(1.0F))
@@ -71,7 +71,7 @@ class FilesystemMomentsTest {
     fun `Counts its moments`() {
         val story = stories.new()
 
-        repeat(10) { story.moments.new().update(TokenableString("Foo")) }
+        repeat(10) { story.new().update(TokenableString("Foo")) }
 
         story.moments.shouldHaveSize(10)
     }
@@ -112,7 +112,7 @@ class FilesystemMomentsTest {
     @Test
     fun `Deletes forgotten moments from the filesystem`() {
         val story = stories.new()
-        val moment = story.moments.new()
+        val moment = story.new()
 
         moment.forget()
 
@@ -122,14 +122,14 @@ class FilesystemMomentsTest {
 
     @Test
     fun `Iterates through moments by descending order of their written dates`() {
-        val moments = stories.new().moments
+        val story = stories.new()
         repeat(10) {
             val randomInstant = Instant.fromEpochMilliseconds((0..Long.MAX_VALUE).random())
-            moments.new().apply { update(Timestamp(randomInstant)) }
+            story.new().apply { update(Timestamp(randomInstant)) }
         }
 
         var previous: Moment? = null
-        moments.forEach { current ->
+        story.moments.forEach { current ->
             if (previous != null) current.compareTo(previous!!).shouldBeLessThanOrEqual(0)
             previous = current
         }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
-import com.hadisatrio.apps.kotlin.journal3.moment.MemorablesCollection
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
@@ -43,7 +43,7 @@ class FilesystemMomentsTest {
     private val fileSystem = FakeFileSystem()
     private val places = FilesystemMemorablePlaces(fileSystem, "content/places".toPath())
     private val people = FilesystemMentionedPeople(fileSystem, "content/people".toPath())
-    private val memorables = MemorablesCollection(places, people)
+    private val memorables = MergedMemorables(places, people)
     private val stories = FilesystemStories(fileSystem, "content/stories".toPath(), memorables)
 
     @AfterTest

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentTest.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.sentiment
 
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.ints.shouldBeNegative
+import io.kotest.matchers.ints.shouldBePositive
+import io.kotest.matchers.ints.shouldBeZero
 import io.kotest.matchers.shouldBe
 import kotlin.test.Test
 
@@ -46,5 +49,12 @@ class SentimentTest {
 
         val averageValue = rawSentiments.map { it.value }.average()
         sentiment.value.shouldBe(averageValue)
+    }
+
+    @Test
+    fun `Compares itself to other sentiment on basis of value`() {
+        Sentiment(1.0F).compareTo(Sentiment(0.5F)).shouldBePositive()
+        Sentiment(1.0F).compareTo(Sentiment(1.0F)).shouldBeZero()
+        Sentiment(0.5F).compareTo(Sentiment(1.0F)).shouldBeNegative()
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
@@ -170,7 +170,7 @@ class EditAStoryUseCaseTest {
     @Test
     fun `Does not delete the story-in-edit when it is an existing one even if the user cancels without editing`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 0, origin = FakeStories())
-        val story = stories.first()
+        val story = stories.first() as EditableStory
         val targetId = FakeTargetId(story.id)
         val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStoriesTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.collections.shouldHaveSize
+import kotlin.test.Test
+
+class MomentfulStoriesTest {
+
+    @Test
+    fun `Filters out stories that has no moments`() {
+        val origin = SelfPopulatingStories(noOfStories = 2, noOfMoments = 1, FakeStories())
+        val momentful = MomentfulStories(origin)
+        origin.first().moments.first().forget()
+
+        momentful.shouldHaveSize(1)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ReflectionTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ReflectionTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ReflectionTest {
+
+    @Test
+    fun `Infers its ID on basis of the given title`() {
+        val title = "Test Reflection"
+        val synopsis = TokenableString("This is a test reflection.")
+        val moments = FakeMoments()
+        val reflection = Reflection(title, synopsis, moments)
+
+        assertEquals(Uuid.nameUUIDFromBytes(title.toByteArray()), reflection.id)
+    }
+
+    @Test
+    fun `Compares itself to other stories on basis of title`() {
+        val title1 = "Test Reflection 1"
+        val title2 = "Test Reflection 2"
+        val synopsis = TokenableString("This is a test reflection.")
+        val moments = FakeMoments()
+        val reflection1 = Reflection(title1, synopsis, moments)
+        val reflection2 = Reflection(title2, synopsis, moments)
+
+        assertEquals(-1, reflection1.compareTo(reflection2))
+        assertEquals(1, reflection2.compareTo(reflection1))
+        assertEquals(0, reflection1.compareTo(reflection1))
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStoryTest.kt
@@ -28,13 +28,13 @@ import org.junit.Test
 
 class UpdateDeferringStoryTest {
 
-    private lateinit var original: Story
+    private lateinit var original: EditableStory
     private lateinit var updateDeferring: UpdateDeferringStory
 
     @Before
     fun `Inits subjects`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, origin = FakeStories())
-        original = stories.first()
+        original = stories.first() as EditableStory
         updateDeferring = UpdateDeferringStory(original)
     }
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStoryTest.kt
@@ -15,10 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.moment.datetime
+package com.hadisatrio.apps.kotlin.journal3.story.datetime
 
+import com.benasher44.uuid.uuid4
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
-import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoments
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -26,13 +27,13 @@ import kotlinx.datetime.Clock
 import kotlin.test.Test
 import kotlin.time.Duration
 
-class ClockRespectingMomentsTest {
+class ClockRespectingStoryTest {
 
     @Test
     fun `Ensures newly-created moments are updated with current timestamp`() {
         val clock = mockk<Clock>()
-        val origin = FakeMoments()
-        val moments = ClockRespectingMoments(clock, origin)
+        val origin = FakeStory(uuid4(), mutableListOf())
+        val moments = ClockRespectingStory(clock, origin)
         val current = Clock.System.now()
         val currentTimestamp = Timestamp(current)
         every { clock.now() } returns current

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
@@ -49,6 +49,12 @@ class FilesystemStoriesTest {
     }
 
     @Test
+    fun `Collects moments from each of its stories`() {
+        val stories = SelfPopulatingStories(noOfStories = 2, noOfMoments = 5, stories)
+        stories.moments.shouldHaveSize(10)
+    }
+
+    @Test
     fun `Writes new stories to the filesystem`() {
         val story = stories.new()
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoriesTest.kt
@@ -18,7 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.story.filesystem
 
 import com.benasher44.uuid.uuid4
-import com.hadisatrio.apps.kotlin.journal3.moment.MemorablesCollection
+import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMemorablePlaces
 import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMentionedPeople
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
@@ -40,7 +40,7 @@ class FilesystemStoriesTest {
     private val fileSystem = FakeFileSystem()
     private val places = FilesystemMemorablePlaces(fileSystem, "content/places".toPath())
     private val people = FilesystemMentionedPeople(fileSystem, "content/people".toPath())
-    private val memorables = MemorablesCollection(places, people)
+    private val memorables = MergedMemorables(places, people)
     private val stories = FilesystemStories(fileSystem, "content/stories".toPath(), memorables)
 
     @AfterTest

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/filesystem/FilesystemStoryTest.kt
@@ -66,7 +66,7 @@ class FilesystemStoryTest {
     fun `Deletes itself from the filesystem`() {
         val story = stories.new()
 
-        story.moments.new()
+        story.new()
         story.forget()
 
         val path = "content/${story.id}".toPath()


### PR DESCRIPTION
### What has changed

#### Segregation of `Story`

We have now differentiated `Story`-ies based on whether users can edit them, allowing the system to generate non-editable stories.

#### `Stories`-wide `Moments`

`Stories` now provide direct access to their `Moments` by merging all moments stored under their children (`Story`).

#### Expanded Decorators for `Moments`

We've added several new decorators for `Moments`:
- `TimeRangedMoments` for filtering based on `ClosedRange<Timestamp>`.
- `SentimentRangedMoments` for filtering based on `ClosedRange<Sentiment>`.
- `VicinityMoments`, allowing filtering based on an anchor `Coordinates` and a radius limit.
- `CountLimitingMoments` for truncation, and
- `OrderRandomizingMoments`, pretty self-explanatory.

#### `Reflection` as a `Story`

The concept of reflections is mainly driven by the user's `Moments`, making it a distinct kind of `Story`. This approach allows us to reuse a lot of domain and presentation infrastructure.

#### Introducing a New Fragment to Surface `Reflections`

We've created a new fragment responsible for presenting `Reflections` to the user. While technically we could reuse `StoriesListingFragment`, there are key differences that would impact UX, so we've made the original class abstract to avoid duplication.

### Why it was changed

Besides my personal desire for this feature as a user, this exercise serves as a compelling showcase of model composability and how it reduces redundancy.

For example, this composition would surface any past `Moments` that have a `Sentiment` value of `0.81` to `1.0` (i.e., very positive):

```kotlin
    Reflection(
        title = "very_positive_moments",
        synopsis = TokenableString("very_positive_moments"),
        moments = CountLimitingMoments(
            limit = 10,
            origin = OrderRandomizingMoments(
                origin = SentimentRangedMoments(
                    sentimentRange = VeryPositiveSentimentRange,
                    origin = stories.moments
                )
            )
        )
    )
```

Now, if we take the same composition and "slip in" `TimeRangedMoments` while removing `CountLimitingMoments` there, we would end up with different behavior. In this case, instead of considering all past `Moments`, we scope it just to the ones written recently (i.e., in the past week):

```kotlin
    Reflection(
        title = "recent_wins",
        synopsis = TokenableString("recent_wins"),
        moments =  OrderRandomizingMoments(
            origin = TimeRangedMoments(
                timeRange = Timestamp(clock.now() - 7.days)..Timestamp(clock.now()),
                origin = SentimentRangedMoments(
                    sentimentRange = VeryPositiveSentimentRange,
                    origin = stories.moments
                )
            )
        )
    )
```

In a way, the different decorators we have for `Moments` serve much like Lego blocks for the domain. This allows us to conserve the need to write new code to satisfy future requirements.

Some more examples:
- `TimeRangedMoments` + `VicinityMoments` could be used to surface all moments that happened in a special location in a particular year.
- `SentimentRangedMoments` + `OrderRandomizingMoments` + `CountLimitingMoments` could be used to surface a select number of random moments with any kinds of `Sentiment` range (e.g., positive, neutral, etc).
- Only `CountLimitingMoments` could be used to show the user's most recent moments (as they are naturally sorted by date-of-writing).
- ...and many more.