### PR TITLE
Enable StrictMode on debug builds

### DIFF
--- a/app-android-journal3/src/debug/AndroidManifest.xml
+++ b/app-android-journal3/src/debug/AndroidManifest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools" tools:node="merge">
+
+    <application tools:node="merge">
+
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="merge">
+            <meta-data
+                android:name="com.hadisatrio.apps.android.journal3.StrictModeInitializer"
+                android:value="androidx.startup" />
+        </provider>
+
+    </application>
+
+</manifest>

--- a/app-android-journal3/src/debug/kotlin/com/hadisatrio/apps/android/journal3/StrictModeInitializer.kt
+++ b/app-android-journal3/src/debug/kotlin/com/hadisatrio/apps/android/journal3/StrictModeInitializer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3
+
+import android.content.Context
+import android.os.StrictMode
+import androidx.startup.Initializer
+
+@Suppress("unused")
+class StrictModeInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyFlashScreen()
+                .penaltyLog()
+                .build()
+        )
+    }
+
+    override fun dependencies(): MutableList<Class<out Initializer<*>>> {
+        return mutableListOf()
+    }
+}

--- a/app-android-journal3/src/main/AndroidManifest.xml
+++ b/app-android-journal3/src/main/AndroidManifest.xml
@@ -35,6 +35,7 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/Theme.Journal3"
+        android:usesCleartextTraffic="false"
         tools:targetApi="31">
 
         <provider

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -32,6 +32,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.filesystem.FilesystemMentioned
 import com.hadisatrio.apps.kotlin.journal3.sentiment.NegativeishSentimentRange
 import com.hadisatrio.apps.kotlin.journal3.sentiment.PositiveishSentimentRange
 import com.hadisatrio.apps.kotlin.journal3.sentiment.VeryPositiveSentimentRange
+import com.hadisatrio.apps.kotlin.journal3.story.InitDeferringStories
 import com.hadisatrio.apps.kotlin.journal3.story.MomentfulStories
 import com.hadisatrio.apps.kotlin.journal3.story.Reflection
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
@@ -103,66 +104,68 @@ class RealJournal3Application : Journal3Application() {
     }
 
     override val reflections: Stories by lazy {
-        MomentfulStories(
-            FakeStories(
-                Reflection(
-                    title = "Around the Corner",
-                    synopsis = TokenableString("Rediscover moments from nearby places."),
-                    moments = CountLimitingMoments(
-                        limit = 10,
-                        origin = OrderRandomizingMoments(
-                            origin = VicinityMoments(
-                                coordinates = coordinates,
-                                distanceLimitInM = 100.0,
-                                origin = stories.moments
+        InitDeferringStories {
+            MomentfulStories(
+                FakeStories(
+                    Reflection(
+                        title = "Around the Corner",
+                        synopsis = TokenableString("Rediscover moments from nearby places."),
+                        moments = CountLimitingMoments(
+                            limit = 10,
+                            origin = OrderRandomizingMoments(
+                                origin = VicinityMoments(
+                                    coordinates = coordinates,
+                                    distanceLimitInM = 100.0,
+                                    origin = stories.moments
+                                )
                             )
                         )
-                    )
-                ),
-                Reflection(
-                    title = "Recent Wins",
-                    synopsis = TokenableString("Celebrate positive moments of the week."),
-                    moments = CountLimitingMoments(
-                        limit = 10,
-                        origin = OrderRandomizingMoments(
-                            origin = TimeRangedMoments(
-                                timeRange = Timestamp(clock.now() - 7.days)..Timestamp(clock.now()),
+                    ),
+                    Reflection(
+                        title = "Recent Wins",
+                        synopsis = TokenableString("Celebrate positive moments of the week."),
+                        moments = CountLimitingMoments(
+                            limit = 10,
+                            origin = OrderRandomizingMoments(
+                                origin = TimeRangedMoments(
+                                    timeRange = Timestamp(clock.now() - 7.days)..Timestamp(clock.now()),
+                                    origin = SentimentRangedMoments(
+                                        sentimentRange = PositiveishSentimentRange,
+                                        origin = stories.moments
+                                    )
+                                )
+                            )
+                        )
+                    ),
+                    Reflection(
+                        title = "Positivity Overload",
+                        synopsis = TokenableString("Immerse in incredibly positive moments."),
+                        moments = CountLimitingMoments(
+                            limit = 10,
+                            origin = OrderRandomizingMoments(
                                 origin = SentimentRangedMoments(
-                                    sentimentRange = PositiveishSentimentRange,
+                                    sentimentRange = VeryPositiveSentimentRange,
+                                    origin = stories.moments
+                                )
+                            )
+                        )
+                    ),
+                    Reflection(
+                        title = "Shadows & Light",
+                        synopsis = TokenableString("Reflect on deeply emotional moments."),
+                        moments = CountLimitingMoments(
+                            limit = 5,
+                            origin = OrderRandomizingMoments(
+                                origin = SentimentRangedMoments(
+                                    sentimentRange = NegativeishSentimentRange,
                                     origin = stories.moments
                                 )
                             )
                         )
                     )
-                ),
-                Reflection(
-                    title = "Positivity Overload",
-                    synopsis = TokenableString("Immerse in incredibly positive moments."),
-                    moments = CountLimitingMoments(
-                        limit = 10,
-                        origin = OrderRandomizingMoments(
-                            origin = SentimentRangedMoments(
-                                sentimentRange = VeryPositiveSentimentRange,
-                                origin = stories.moments
-                            )
-                        )
-                    )
-                ),
-                Reflection(
-                    title = "Shadows & Light",
-                    synopsis = TokenableString("Reflect on deeply emotional moments."),
-                    moments = CountLimitingMoments(
-                        limit = 5,
-                        origin = OrderRandomizingMoments(
-                            origin = SentimentRangedMoments(
-                                sentimentRange = NegativeishSentimentRange,
-                                origin = stories.moments
-                            )
-                        )
-                    )
                 )
             )
-        )
+        }
     }
 
     override val modalPresenter: Presenter<Modal> by lazy {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoment.kt
@@ -24,6 +24,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
+import com.hadisatrio.libs.kotlin.geography.cache.CachingPlace
 
 @Suppress("LongParameterList")
 class CachingMoment(
@@ -43,7 +44,7 @@ class CachingMoment(
         origin.description,
         origin.sentiment,
         origin.impliedSentiment,
-        origin.place,
+        CachingPlace(origin.place),
         origin.attachments,
         origin
     )

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStories.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+
+class InitDeferringStories(
+    private val provider: () -> Stories
+) : Stories {
+
+    private val origin: Stories by lazy(provider)
+    override val moments: Moments get() = origin.moments
+
+    override fun new(): EditableStory {
+        return origin.new()
+    }
+
+    override fun containsStory(id: Uuid): Boolean {
+        return origin.containsStory(id)
+    }
+
+    override fun findStory(id: Uuid): Iterable<Story> {
+        return origin.findStory(id)
+    }
+
+    override fun hasMoments(): Boolean {
+        return origin.hasMoments()
+    }
+
+    override fun containsMoment(id: Uuid): Boolean {
+        return origin.containsMoment(id)
+    }
+
+    override fun findMoment(id: Uuid): Iterable<Moment> {
+        return origin.findMoment(id)
+    }
+
+    override fun mostRecentMoment(): Moment {
+        return origin.mostRecentMoment()
+    }
+
+    override fun iterator(): Iterator<Story> {
+        return origin.iterator()
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStoriesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStoriesTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlin.test.Test
+
+class InitDeferringStoriesTest {
+
+    @Test
+    fun `Defers the initialization of its origin`() {
+        var isInitialized = false
+        val origin = { isInitialized = true; FakeStories() }
+        val deferred = InitDeferringStories(origin)
+
+        isInitialized.shouldBeFalse()
+        deferred.moments
+        isInitialized.shouldBeTrue()
+    }
+}

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/cache/CachingPlace.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/cache/CachingPlace.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.geography.cache
+
+import com.benasher44.uuid.Uuid
+import com.hadisatrio.libs.kotlin.geography.Coordinates
+import com.hadisatrio.libs.kotlin.geography.Place
+
+class CachingPlace(
+    override val id: Uuid,
+    override val name: String,
+    override val address: String,
+    override val coordinates: Coordinates,
+    private val origin: Place
+) : Place by origin {
+
+    constructor(place: Place) : this(
+        place.id,
+        place.name,
+        place.address,
+        place.coordinates,
+        place
+    )
+}

--- a/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/cache/CachingPlaceTest.kt
+++ b/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/cache/CachingPlaceTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.geography.cache
+
+import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
+import io.mockk.spyk
+import io.mockk.verify
+import kotlin.test.Test
+
+class CachingPlaceTest {
+
+    @Test
+    fun `Prevents multiple property access to the original place`() {
+        val origin = spyk(FakePlace())
+        val cached = CachingPlace(origin)
+
+        repeat(times = 10) { cached.id }
+        repeat(times = 10) { cached.name }
+        repeat(times = 10) { cached.coordinates }
+        repeat(times = 10) { cached.address }
+
+        verify(exactly = 1) { origin.id }
+        verify(exactly = 1) { origin.name }
+        verify(exactly = 1) { origin.coordinates }
+        verify(exactly = 1) { origin.address }
+    }
+}


### PR DESCRIPTION
### What has changed

#### `StrictMode` on debug builds

`StrictMode` is now enabled in debug builds. Set with `detectAll()` and `penaltyFlashScreen()` plus `penaltyLog()`, it should help us catch performance issues during development.

#### `CachingPlace`

`CachingMoment` missed out on wrapping its `Place` object with a similar wrapper. This oversight has now been addressed.

#### Lazy initialization of reflection `Stories`

Reflection `Stories` call upon the main `Stories`' `Moments` during initialization. Despite itself has already been wrapped with `lazy {}`, the initialization would still happen on the Main thread. With the help of `InitDeferringStories`, we addressed the issue by ensuring that the object won't be instantiated until a method is called (which will happen on a worker thread rather than Main, courtesy of `ExecutorDispatchingUseCase`).

### Why was it changed

To ensure that we won't trouble ourselves with a huge backlog of performance issues in the future.