### PR TITLE
Improve readability of timestamps

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -19,7 +19,9 @@ package com.hadisatrio.apps.android.journal3
 
 import android.app.Application
 import android.content.Context
+import android.view.View
 import androidx.fragment.app.Fragment
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -39,6 +41,7 @@ abstract class Journal3Application : Application() {
     abstract val currentActivity: CurrentActivity
     abstract val globalEventSink: EventSink
     abstract val globalEventSource: EventSource
+    abstract val timestampDecor: Timestamp.Decor
     abstract val inactivityAlertThreshold: Duration
     abstract val clock: Clock
     abstract val backgroundExecutor: Executor
@@ -50,3 +53,6 @@ val Context.journal3Application: Journal3Application
 
 val Fragment.journal3Application: Journal3Application
     get() = requireContext().journal3Application
+
+val View.journal3Application: Journal3Application
+    get() = context.journal3Application

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -19,7 +19,9 @@ package com.hadisatrio.apps.android.journal3
 
 import androidx.core.content.ContextCompat
 import com.google.android.material.color.DynamicColors
+import com.hadisatrio.apps.kotlin.journal3.datetime.FormattedTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.CountLimitingMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.OrderRandomizingMoments
@@ -188,6 +190,10 @@ class RealJournal3Application : Journal3Application() {
 
     override val globalEventSource: EventSource by lazy {
         EventHub(MutableSharedFlow(extraBufferCapacity = 1))
+    }
+
+    override val timestampDecor: Timestamp.Decor by lazy {
+        Timestamp.Decor { FormattedTimestamp("EEEE, d MMMM yyyy '·' hh:mm", it) }
     }
 
     override val inactivityAlertThreshold: Duration by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.apps.android.journal3
 
 import androidx.core.content.ContextCompat
 import com.google.android.material.color.DynamicColors
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.CountLimitingMoments
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.OrderRandomizingMoments
@@ -128,7 +128,7 @@ class RealJournal3Application : Journal3Application() {
                             limit = 10,
                             origin = OrderRandomizingMoments(
                                 origin = TimeRangedMoments(
-                                    timeRange = Timestamp(clock.now() - 7.days)..Timestamp(clock.now()),
+                                    timeRange = LiteralTimestamp(clock.now() - 7.days)..LiteralTimestamp(clock.now()),
                                     origin = SentimentRangedMoments(
                                         sentimentRange = PositiveishSentimentRange,
                                         origin = stories.moments

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
@@ -29,6 +29,7 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
+import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.UnixEpoch
@@ -135,7 +136,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
 
     internal fun applySelection(timestamp: Timestamp) {
         selection = timestamp
-        text = timestamp.toString()
+        text = journal3Application.timestampDecor.apply(timestamp).toString()
         listener?.onTimeStampSelected(timestamp)
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/datetime/TimestampSelectorButton.kt
@@ -29,7 +29,9 @@ import androidx.fragment.app.DialogFragment
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.timepicker.MaterialTimePicker
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.UnixEpoch
 import com.hadisatrio.libs.android.fragment.supportFragmentManager
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
@@ -44,7 +46,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
 ) : MaterialButton(context, attrs),
     View.OnClickListener {
 
-    private var selection: Timestamp = Timestamp.DEFAULT
+    private var selection: Timestamp = UnixEpoch
     private var activePicker: DialogFragment? = null
     private var listener: OnTimestampSelectedListener? = null
 
@@ -128,7 +130,7 @@ class TimestampSelectorButton @JvmOverloads constructor(
     }
 
     private fun applySelection(instant: Instant) {
-        applySelection(Timestamp(instant))
+        applySelection(LiteralTimestamp(instant))
     }
 
     internal fun applySelection(timestamp: Timestamp) {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -62,7 +62,7 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
         }
         val subItemViewRenderer = RecyclerViewPresenter.ViewRenderer<Moment> { view, item ->
             view.findViewById<TextView>(R.id.date_and_place_label).text =
-                "${item.timestamp} at ${item.place.name}"
+                "${journal3Application.timestampDecor.apply(item.timestamp)} · ${item.place.name}"
             view.findViewById<TextView>(R.id.description_label).text =
                 item.description.toString()
             view.findViewById<TextView>(R.id.mood_and_attachment_count_label).text =

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -18,6 +18,7 @@
 package com.hadisatrio.apps.android.journal3
 
 import androidx.core.content.ContextCompat
+import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
@@ -48,6 +49,7 @@ class FakeJournal3Application : Journal3Application() {
     override val currentActivity: CurrentActivity by lazy { CurrentActivity(this) }
     override val globalEventSink: EventSink by lazy { FakeEventSink() }
     override val globalEventSource: EventSource by lazy { EventHub(MutableSharedFlow(extraBufferCapacity = 1)) }
+    override val timestampDecor: Timestamp.Decor by lazy { Timestamp.Decor { it } }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val clock: Clock by lazy { Clock.System }
     override val backgroundExecutor: Executor by lazy { Executors.newFixedThreadPool(1) }

--- a/app-kmm-journal3/src/androidMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestamp.kt
+++ b/app-kmm-journal3/src/androidMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestamp.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.datetime
+
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+class FormattedTimestamp(
+    private val locale: Locale,
+    private val timeZone: TimeZone,
+    private val format: String,
+    private val origin: Timestamp
+) : Timestamp by origin {
+
+    private val formatter = ThreadLocal<SimpleDateFormat>()
+
+    constructor(format: String, origin: Timestamp) : this(Locale.getDefault(), TimeZone.getDefault(), format, origin)
+
+    override fun toString(): String {
+        val localFormatter = formatter.get() ?: SimpleDateFormat(format, locale)
+        localFormatter.timeZone = timeZone
+        formatter.set(localFormatter)
+        return localFormatter.format(Date(value.toEpochMilliseconds()))
+    }
+}

--- a/app-kmm-journal3/src/androidUnitTest/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestampTest.kt
+++ b/app-kmm-journal3/src/androidUnitTest/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestampTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.datetime
+
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import java.util.Locale
+import java.util.TimeZone
+
+class FormattedTimestampTest {
+
+    @Test
+    fun `Converts itself to formatted string`() {
+        val timestamp = LiteralTimestamp(718340400000) // 1992-10-06T03:00:00Z
+        val formattedTimestamp1 = FormattedTimestamp("yyyy-MM-dd", timestamp)
+        val formattedTimestamp2 = FormattedTimestamp("MMM dd, yyyy", timestamp)
+        formattedTimestamp1.toString().shouldBe("1992-10-06")
+        formattedTimestamp2.toString().shouldBe("Oct 06, 1992")
+    }
+
+    @Test
+    fun `Converts itself to formatted and localized string`() {
+        val timestamp = LiteralTimestamp(718340400000) // 1992-10-06T03:00:00Z
+        val locale = Locale.US
+        val timeZone = TimeZone.getTimeZone("Asia/Jakarta")
+        val formattedTimestamp = FormattedTimestamp(locale, timeZone, "hh:mm", timestamp)
+        formattedTimestamp.toString().shouldBe("10:00")
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.alert
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
@@ -56,7 +56,7 @@ class AlertInactivityUseCase(
 
     private fun isAlertNecessary(): Boolean {
         if (!stories.hasMoments()) return true
-        val currentTimestamp = Timestamp(Clock.System.now())
+        val currentTimestamp = LiteralTimestamp(Clock.System.now())
         val mostRecentTimestamp = stories.mostRecentMoment().timestamp
         return currentTimestamp.difference(mostRecentTimestamp) > threshold
     }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/LiteralTimestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/LiteralTimestamp.kt
@@ -18,23 +18,28 @@
 package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
-import kotlin.time.Duration
 
-interface Timestamp : Comparable<Timestamp> {
+class LiteralTimestamp(
+    override val value: Instant
+) : Timestamp {
 
-    val value: Instant
+    constructor(iso8601: String) : this(Instant.parse(iso8601))
 
-    fun toEpochMilliseconds(): Long {
-        return value.toEpochMilliseconds()
+    constructor(epochMilliseconds: Long) : this(Instant.fromEpochMilliseconds(epochMilliseconds))
+
+    override fun toString(): String {
+        return value.toString()
     }
 
-    fun difference(other: Timestamp): Duration {
-        return this.value - other.value
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null) return false
+        if (this::class != other::class) return false
+        other as LiteralTimestamp
+        return value == other.value
     }
 
-    override fun compareTo(other: Timestamp): Int {
-        return value.compareTo(other.value)
+    override fun hashCode(): Int {
+        return value.hashCode()
     }
-
-    override fun toString(): String
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
@@ -37,4 +37,8 @@ interface Timestamp : Comparable<Timestamp> {
     }
 
     override fun toString(): String
+
+    fun interface Decor {
+        fun apply(origin: Timestamp): Timestamp
+    }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/UnixEpoch.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/UnixEpoch.kt
@@ -18,23 +18,12 @@
 package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
-import kotlin.time.Duration
 
-interface Timestamp : Comparable<Timestamp> {
+object UnixEpoch : Timestamp {
 
-    val value: Instant
+    override val value: Instant = Instant.fromEpochMilliseconds(0)
 
-    fun toEpochMilliseconds(): Long {
-        return value.toEpochMilliseconds()
+    override fun toString(): String {
+        return value.toString()
     }
-
-    fun difference(other: Timestamp): Duration {
-        return this.value - other.value
-    }
-
-    override fun compareTo(other: Timestamp): Int {
-        return value.compareTo(other.value)
-    }
-
-    override fun toString(): String
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -20,7 +20,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.benasher44.uuid.uuidFrom
 import com.chrynan.uri.core.Uri
 import com.chrynan.uri.core.fromString
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.id.TargetId
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
@@ -124,7 +124,7 @@ class EditAMomentUseCase(
         val kind = event.selectionKind
         val identifier = event.selectedIdentifier
         when (kind) {
-            "timestamp" -> currentTarget.update(Timestamp(identifier))
+            "timestamp" -> currentTarget.update(LiteralTimestamp(identifier))
             "sentiment" -> currentTarget.update(Sentiment(identifier))
             "place" -> currentTarget.update(places.findPlace(uuidFrom(identifier)).first())
             "attachments" -> currentTarget.update(identifier.split(',').map { Uri.fromString(it) })

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/fake/FakeMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/fake/FakeMoment.kt
@@ -20,6 +20,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment.fake
 import com.benasher44.uuid.Uuid
 import com.chrynan.uri.core.Uri
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.UnixEpoch
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
@@ -33,7 +34,7 @@ class FakeMoment(
 
     private var isForgotten: Boolean = false
 
-    override var timestamp: Timestamp = Timestamp.DEFAULT
+    override var timestamp: Timestamp = UnixEpoch
         private set
     override var description: TokenableString = TokenableString.EMPTY
         private set

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
@@ -20,7 +20,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 import com.benasher44.uuid.Uuid
 import com.benasher44.uuid.uuidFrom
 import com.chrynan.uri.core.Uri
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.UnixEpoch
 import com.hadisatrio.apps.kotlin.journal3.moment.MemorableFile
 import com.hadisatrio.apps.kotlin.journal3.moment.Memorables
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
@@ -44,7 +46,7 @@ class FilesystemMoment(
     }
 
     override val timestamp: Timestamp get() {
-        return Timestamp(file.getRaw("timestamp") ?: return Timestamp.DEFAULT)
+        return LiteralTimestamp(file.getRaw("timestamp") ?: return UnixEpoch)
     }
 
     override val description: TokenableString get() {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.story
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import kotlinx.datetime.Clock
 
@@ -38,7 +38,7 @@ class SelfPopulatingStories(
             repeat(noOfMoments) { rep2 ->
                 new().apply {
                     update(TokenableString("This is a moment (#$rep-$rep2)."))
-                    update(Timestamp(Clock.System.now()))
+                    update(LiteralTimestamp(Clock.System.now()))
                 }
             }
         }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStory.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.story.datetime
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.story.EditableStory
 import kotlinx.datetime.Clock
@@ -29,7 +29,7 @@ class ClockRespectingStory(
 
     override fun new(): Moment {
         val moment = origin.new()
-        moment.update(Timestamp(clock.now()))
+        moment.update(LiteralTimestamp(clock.now()))
         return moment
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.alert
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
@@ -45,7 +45,7 @@ class AlertInactivityUseCaseTest {
 
     @Test
     fun `Presents a modal should last written moment timestamp exceeds threshold`() {
-        moment.update(Timestamp(Clock.System.now() - 1.days))
+        moment.update(LiteralTimestamp(Clock.System.now() - 1.days))
 
         AlertInactivityUseCase(
             threshold = 3.hours,
@@ -77,7 +77,7 @@ class AlertInactivityUseCaseTest {
 
     @Test
     fun `Does nothing should last written moment timestamp is under threshold`() {
-        moment.update(Timestamp(Clock.System.now() - 1.hours))
+        moment.update(LiteralTimestamp(Clock.System.now() - 1.hours))
 
         AlertInactivityUseCase(
             threshold = 3.hours,
@@ -94,7 +94,7 @@ class AlertInactivityUseCaseTest {
 
     @Test
     fun `Routes to the moment editor when receiving modal approval for 'inactivity_alert'`() {
-        moment.update(Timestamp(Clock.System.now() - 1.days))
+        moment.update(LiteralTimestamp(Clock.System.now() - 1.days))
 
         AlertInactivityUseCase(
             threshold = 3.hours,
@@ -121,7 +121,7 @@ class AlertInactivityUseCaseTest {
 
     @Test(timeout = 5_000)
     fun `Stops upon receiving cancellation events`() {
-        moment.update(Timestamp(Clock.System.now() - 1.days))
+        moment.update(LiteralTimestamp(Clock.System.now() - 1.days))
 
         listOf(CancellationEvent("user"), CancellationEvent("system")).forEach { event ->
             AlertInactivityUseCase(
@@ -136,7 +136,7 @@ class AlertInactivityUseCaseTest {
 
     @Test
     fun `Ignores unknown events without repercussions`() {
-        moment.update(Timestamp(Clock.System.now() - 1.days))
+        moment.update(LiteralTimestamp(Clock.System.now() - 1.days))
 
         AlertInactivityUseCase(
             threshold = 3.hours,

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.geography
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
@@ -106,7 +106,7 @@ class SelectAPlaceUseCaseTest {
             presenter = mockk(relaxed = true),
             eventSource = RecordedEventSource(
                 TextInputEvent("foo", "Bar"),
-                SelectionEvent("fizz", Timestamp(Instant.DISTANT_FUTURE).toString()),
+                SelectionEvent("fizz", LiteralTimestamp(Instant.DISTANT_FUTURE).toString()),
                 SelectionEvent("buzz", Sentiment(0.75F).toString()),
                 ModalApprovalEvent("lorem"),
                 CancellationEvent("system"),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
@@ -17,7 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.moment
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.id.FakeTargetId
@@ -70,7 +70,7 @@ class EditAMomentUseCaseTest {
             modalPresenter = modalPresenter,
             eventSource = RecordedEventSource(
                 TextInputEvent("description", "Foo"),
-                SelectionEvent("timestamp", Timestamp(Instant.DISTANT_FUTURE).toString()),
+                SelectionEvent("timestamp", LiteralTimestamp(Instant.DISTANT_FUTURE).toString()),
                 SelectionEvent("sentiment", Sentiment(0.75F).toString()),
                 SelectionEvent("place", place.id.toString()),
                 SelectionEvent("attachments", "content://foo,content://bar"),
@@ -82,7 +82,7 @@ class EditAMomentUseCaseTest {
 
         story.moments.shouldHaveSize(1)
         moment.description.toString().shouldBe("Foo")
-        moment.timestamp.shouldBe(Timestamp(Instant.DISTANT_FUTURE))
+        moment.timestamp.shouldBe(LiteralTimestamp(Instant.DISTANT_FUTURE))
         moment.sentiment.shouldBe(Sentiment(0.75F))
         moment.place.id.shouldBe(place.id)
         moment.attachments.shouldHaveSize(2)
@@ -102,7 +102,7 @@ class EditAMomentUseCaseTest {
             modalPresenter = modalPresenter,
             eventSource = RecordedEventSource(
                 TextInputEvent("description", "Foo"),
-                SelectionEvent("timestamp", Timestamp(Instant.DISTANT_FUTURE).toString()),
+                SelectionEvent("timestamp", LiteralTimestamp(Instant.DISTANT_FUTURE).toString()),
                 SelectionEvent("sentiment", Sentiment(0.75F).toString()),
                 CompletionEvent()
             ),
@@ -112,7 +112,7 @@ class EditAMomentUseCaseTest {
 
         story.moments.shouldHaveSize(1)
         story.moments.first().description.toString().shouldBe("Foo")
-        story.moments.first().timestamp.shouldBe(Timestamp(Instant.DISTANT_FUTURE))
+        story.moments.first().timestamp.shouldBe(LiteralTimestamp(Instant.DISTANT_FUTURE))
         story.moments.first().sentiment.shouldBe(Sentiment(0.75F))
     }
 
@@ -316,7 +316,7 @@ class EditAMomentUseCaseTest {
             eventSource = RecordedEventSource(
                 TextInputEvent("foo", "Bar"),
                 SelectionEvent("action", "foo"),
-                SelectionEvent("fizz", Timestamp(Instant.DISTANT_FUTURE).toString()),
+                SelectionEvent("fizz", LiteralTimestamp(Instant.DISTANT_FUTURE).toString()),
                 SelectionEvent("buzz", Sentiment(0.75F).toString()),
                 ModalApprovalEvent("lorem"),
                 CancellationEvent("system"),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMomentsTest.kt
@@ -17,6 +17,7 @@
 
 package com.hadisatrio.apps.kotlin.journal3.moment
 
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
@@ -31,13 +32,15 @@ class TimeRangedMomentsTest {
 
     private val currentInstant: Instant = Clock.System.now()
     private val origin: Moments = SelfPopulatingStories(noOfStories = 1, noOfMoments = 10, FakeStories()).moments
-    private val timeRange: ClosedRange<Timestamp> = Timestamp(currentInstant - 3.days)..Timestamp(currentInstant)
+    private val timeRange: ClosedRange<Timestamp> = LiteralTimestamp(currentInstant - 3.days)..LiteralTimestamp(
+        currentInstant
+    )
     private val moments: TimeRangedMoments = TimeRangedMoments(timeRange, origin)
 
     @BeforeTest
     fun `Init moments`() {
         origin.forEachIndexed { index, moment ->
-            moment.update(Timestamp(currentInstant - index.days))
+            moment.update(LiteralTimestamp(currentInstant - index.days))
         }
     }
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMomentTest.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.chrynan.uri.core.Uri
 import com.chrynan.uri.core.fromString
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
@@ -48,7 +48,7 @@ class UpdateDeferringMomentTest {
 
     @Test
     fun `Defers updates to the original until its committed`() {
-        updateDeferring.update(Timestamp(Instant.DISTANT_FUTURE))
+        updateDeferring.update(LiteralTimestamp(Instant.DISTANT_FUTURE))
         updateDeferring.update(TokenableString("foo"))
         updateDeferring.update(Sentiment(0.75F))
         updateDeferring.update(FakePlace())
@@ -75,7 +75,7 @@ class UpdateDeferringMomentTest {
             updatesMade().shouldBeFalse()
         }
         UpdateDeferringMoment(original).run {
-            update(Timestamp(Instant.DISTANT_FUTURE))
+            update(LiteralTimestamp(Instant.DISTANT_FUTURE))
             updatesMade().shouldBeTrue()
         }
         UpdateDeferringMoment(original).run {
@@ -98,7 +98,7 @@ class UpdateDeferringMomentTest {
 
     @Test
     fun `Compares based on edited timestamp, even prior to committing`() {
-        updateDeferring.update(Timestamp(Instant.DISTANT_FUTURE))
+        updateDeferring.update(LiteralTimestamp(Instant.DISTANT_FUTURE))
         updateDeferring.compareTo(original).shouldBe(1)
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentTest.kt
@@ -17,7 +17,8 @@
 
 package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.UnixEpoch
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.story.filesystem.FilesystemStories
@@ -66,7 +67,7 @@ class FilesystemMomentTest {
     fun `Returns expected default values`() {
         val moment = story.new()
 
-        moment.timestamp.shouldBe(Timestamp(Instant.fromEpochMilliseconds(0)))
+        moment.timestamp.shouldBe(UnixEpoch)
         moment.description.shouldBe(TokenableString(""))
         moment.sentiment.shouldBe(Sentiment(0.123456789F))
         moment.place.shouldBe(NullIsland)
@@ -77,7 +78,7 @@ class FilesystemMomentTest {
     fun `Writes details updates to the filesystem`() {
         val moment = story.new()
 
-        moment.update(timestamp = Timestamp(Instant.fromEpochMilliseconds(1000)))
+        moment.update(timestamp = LiteralTimestamp(1000))
         moment.update(description = TokenableString("Foo"))
         moment.update(sentiment = Sentiment(0.5F))
 
@@ -85,7 +86,7 @@ class FilesystemMomentTest {
         val fileContent = fileSystem.source(path).buffer().use { it.readUtf8() }
         fileContent.shouldContain("Foo")
         fileContent.shouldContain("0.5")
-        moment.timestamp.shouldBe(Timestamp(Instant.fromEpochMilliseconds(1000)))
+        moment.timestamp.shouldBe(LiteralTimestamp(1000))
         moment.description.shouldBe(TokenableString("Foo"))
         moment.sentiment.shouldBe(Sentiment(0.5F))
     }
@@ -170,8 +171,8 @@ class FilesystemMomentTest {
     @Test
     fun `Compares itself to others based on timestamp`() {
         val self = story.new()
-        val newer = story.new().apply { update(Timestamp(Instant.DISTANT_FUTURE)) }
-        val older = story.new().apply { update(Timestamp(Instant.DISTANT_PAST)) }
+        val newer = story.new().apply { update(LiteralTimestamp(Instant.DISTANT_FUTURE)) }
+        val older = story.new().apply { update(LiteralTimestamp(Instant.DISTANT_PAST)) }
 
         self.compareTo(newer).shouldBeNegative()
         self.compareTo(older).shouldBePositive()

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMomentsTest.kt
@@ -18,7 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.moment.filesystem
 
 import com.benasher44.uuid.uuid4
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.moment.MergedMemorables
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
@@ -58,12 +58,12 @@ class FilesystemMomentsTest {
 
         moment.update(TokenableString("FizzBuzz"))
         moment.update(Sentiment(1.0F))
-        moment.update(Timestamp("2019-07-07T20:00:00+07:00"))
+        moment.update(LiteralTimestamp("2019-07-07T20:00:00+07:00"))
 
         story.moments.shouldHaveSize(1)
         moment.description.shouldBe(TokenableString("FizzBuzz"))
         moment.sentiment.shouldBe(Sentiment(1.0F))
-        moment.timestamp.shouldBe(Timestamp("2019-07-07T20:00:00+07:00"))
+        moment.timestamp.shouldBe(LiteralTimestamp("2019-07-07T20:00:00+07:00"))
         fileSystem.metadata("content/stories/${story.id}/moments/${moment.id}".toPath()).isRegularFile.shouldBeTrue()
     }
 
@@ -125,7 +125,7 @@ class FilesystemMomentsTest {
         val story = stories.new()
         repeat(10) {
             val randomInstant = Instant.fromEpochMilliseconds((0..Long.MAX_VALUE).random())
-            story.new().apply { update(Timestamp(randomInstant)) }
+            story.new().apply { update(LiteralTimestamp(randomInstant)) }
         }
 
         var previous: Moment? = null

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
@@ -18,7 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.story
 
 import com.benasher44.uuid.uuid4
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.event.UnsupportedEvent
 import com.hadisatrio.apps.kotlin.journal3.id.FakeTargetId
 import com.hadisatrio.apps.kotlin.journal3.id.InvalidTargetId
@@ -223,7 +223,7 @@ class EditAStoryUseCaseTest {
             modalPresenter = mockk(relaxed = true),
             eventSource = RecordedEventSource(
                 TextInputEvent("foo", "Bar"),
-                SelectionEvent("fizz", Timestamp(Instant.DISTANT_FUTURE).toString()),
+                SelectionEvent("fizz", LiteralTimestamp(Instant.DISTANT_FUTURE).toString()),
                 SelectionEvent("buzz", Sentiment(0.75F).toString()),
                 ModalApprovalEvent("lorem"),
                 CancellationEvent("system"),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/datetime/ClockRespectingStoryTest.kt
@@ -18,7 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.story.datetime
 
 import com.benasher44.uuid.uuid4
-import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -35,7 +35,7 @@ class ClockRespectingStoryTest {
         val origin = FakeStory(uuid4(), mutableListOf())
         val moments = ClockRespectingStory(clock, origin)
         val current = Clock.System.now()
-        val currentTimestamp = Timestamp(current)
+        val currentTimestamp = LiteralTimestamp(current)
         every { clock.now() } returns current
 
         val moment = moments.new()


### PR DESCRIPTION
### What has changed

#### `Timestamp` as an interface
The `value class` `Timestamp` has now been turned into becoming an `interface` instead. The original implementation remains, with a different name of `LiteralTimestamp`.

#### Addition of `FormattedTimestamp`
A `Timestamp` decorator that could be used to localize and format the output of `Timestamp#toString()` basing on a given format string and `Locale`.

#### Application-wide `Timestamp.Decor`
We now provide a `Timestamp.Decor` object as an application-wide dependency. Doing so allowed us to centralize the timestamp formatting used throughout the application

### Why it was changed
The original state of `Timestamp` rendition wasn't exactly readable nor was it user-friendly.