### PR TITLE
Fix UI glitches during state refresh

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceItemDiffer.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceItemDiffer.kt
@@ -15,23 +15,20 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.geography.fake
+package com.hadisatrio.apps.android.journal3.geography
 
-import com.benasher44.uuid.Uuid
-import com.benasher44.uuid.uuid4
-import com.hadisatrio.libs.kotlin.geography.Coordinates
-import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.kotlin.geography.Place
-import kotlin.random.Random
 
-@Suppress("MagicNumber")
-class FakePlace(
-    override val id: Uuid =
-        uuid4(),
-    override val name: String =
-        "Fake Building ${Random.nextInt(100, 999)}",
-    override val address: String =
-        "${Random.nextInt(1, 999)} Fake Street, Phonytown, FK ${Random.nextInt(10000, 99999)}",
-    override val coordinates: Coordinates =
-        LiteralCoordinates("${Random.nextDouble(-90.0, 90.0)},${Random.nextDouble(-180.0, 180.0)}")
-) : Place
+object PlaceItemDiffer : RecyclerViewPresenter.ItemDiffer<Place> {
+
+    override fun areItemsTheSame(oldItem: Place, newItem: Place): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Place, newItem: Place): Boolean {
+        return oldItem.name == newItem.name &&
+            oldItem.address == newItem.address &&
+            oldItem.coordinates == newItem.coordinates
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentItemDiffer.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentItemDiffer.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
+
+object MomentItemDiffer : RecyclerViewPresenter.ItemDiffer<Moment> {
+
+    override fun areItemsTheSame(oldItem: Moment, newItem: Moment): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Moment, newItem: Moment): Boolean {
+        return oldItem.timestamp == newItem.timestamp &&
+            oldItem.description == newItem.description &&
+            oldItem.sentiment == newItem.sentiment &&
+            oldItem.place == newItem.place &&
+            oldItem.attachments.toSet() == newItem.attachments.toSet()
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -28,6 +28,7 @@ import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.android.journal3.moment.MomentCardViewRenderer
+import com.hadisatrio.apps.android.journal3.moment.MomentItemDiffer
 import com.hadisatrio.apps.android.journal3.sentiment.TextViewColorSentimentPresenter
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
@@ -72,7 +73,8 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
                 recyclerView = carousel,
                 viewFactory = subItemViewFactory,
                 viewRenderer = MomentCardViewRenderer,
-                layoutManager = LinearLayoutManager(parent.context, LinearLayoutManager.HORIZONTAL, false)
+                layoutManager = LinearLayoutManager(parent.context, LinearLayoutManager.HORIZONTAL, false),
+                differ = MomentItemDiffer
             )
             carousel.addItemDecoration(SpacingItemDecoration(Spacing(horizontal = 8.dp)))
             view.setTag(R.id.presenter_view_tag, carouselPresenter)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -94,7 +94,8 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
                         origin = RecyclerViewPresenter(
                             recyclerView = storiesListView,
                             viewFactory = itemViewFactory,
-                            viewRenderer = itemViewRenderer
+                            viewRenderer = itemViewRenderer,
+                            differ = StoryItemDiffer
                         )
                     )
                 )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoryItemDiffer.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoryItemDiffer.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.story.Story
+import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
+
+object StoryItemDiffer : RecyclerViewPresenter.ItemDiffer<Story> {
+
+    override fun areItemsTheSame(oldItem: Story, newItem: Story): Boolean {
+        return oldItem.id == newItem.id
+    }
+
+    override fun areContentsTheSame(oldItem: Story, newItem: Story): Boolean {
+        return oldItem.title == newItem.title &&
+            oldItem.synopsis == newItem.synopsis &&
+            areMomentsTheSame(oldItem, newItem)
+    }
+
+    private fun areMomentsTheSame(oldItem: Story, newItem: Story): Boolean {
+        val oldIds = oldItem.moments.mapTo(HashSet()) { it.id }
+        val newIds = newItem.moments.mapTo(HashSet()) { it.id }
+        return oldIds == newIds
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -58,7 +58,8 @@ class UserStoriesListFragment : StoriesListFragment() {
                             viewRenderer = { view, item ->
                                 view.findViewById<TextView>(R.id.title_label).text = item.title
                                 view.findViewById<TextView>(R.id.synopsis_label).text = item.synopsis.toString()
-                            }
+                            },
+                            differ = StoryItemDiffer
                         ),
                         adapter = { stories -> stories.toList() }
                     )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -29,6 +29,7 @@ import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.id.BundledTargetId
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.android.journal3.moment.MomentCardViewRenderer
+import com.hadisatrio.apps.android.journal3.moment.MomentItemDiffer
 import com.hadisatrio.apps.android.journal3.sentiment.TextViewColorSentimentPresenter
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
@@ -86,7 +87,8 @@ class ViewStoryActivity : AppCompatActivity() {
             origin = RecyclerViewPresenter(
                 recyclerView = findViewById(R.id.moments_list),
                 viewFactory = momentsViewFactory,
-                viewRenderer = MomentCardViewRenderer
+                viewRenderer = MomentCardViewRenderer,
+                differ = MomentItemDiffer
             )
         )
 

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -55,6 +55,6 @@ class FakeJournal3Application : Journal3Application() {
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }
     override val clock: Clock by lazy { Clock.System }
-    override val backgroundExecutor: Executor by lazy { Executors.newFixedThreadPool(1) }
+    override val backgroundExecutor: Executor by lazy { Executors.newFixedThreadPool(2) }
     override val foregroundExecutor: Executor by lazy { ContextCompat.getMainExecutor(this) }
 }

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceItemDifferTest.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/geography/PlaceItemDifferTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.geography
+
+import com.benasher44.uuid.uuid4
+import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
+import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import org.junit.Test
+
+class PlaceItemDifferTest {
+
+    @Test
+    fun `Reports two places with differing IDs as being different`() {
+        val one = FakePlace(uuid4())
+        val another = FakePlace(uuid4())
+
+        PlaceItemDiffer.areItemsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two places with the same ID as being same`() {
+        val id = uuid4()
+        val one = FakePlace(id)
+        val another = FakePlace(id)
+
+        PlaceItemDiffer.areItemsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two places with identical content as being same content-wise`() {
+        val id = uuid4()
+        val name = "Foo"
+        val address = "Bar"
+        val coordinates = LiteralCoordinates("-7.607355,110.203804")
+        val one = FakePlace(id, name, address, coordinates)
+        val another = FakePlace(id, name, address, coordinates)
+
+        PlaceItemDiffer.areContentsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two places with differing name as being different content-wise`() {
+        val id = uuid4()
+        val one = FakePlace(id = id, name = "Foo")
+        val another = FakePlace(id = id, name = "Bar")
+
+        PlaceItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two places with differing address as being different content-wise`() {
+        val id = uuid4()
+        val one = FakePlace(id = id, address = "Foo")
+        val another = FakePlace(id = id, address = "Bar")
+
+        PlaceItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two places with differing coordinates as being different content-wise`() {
+        val id = uuid4()
+        val one = FakePlace(id = id, coordinates = LiteralCoordinates("-7.607355,110.203804"))
+        val another = FakePlace(id = id, coordinates = LiteralCoordinates("37.5323749,-122.4151854"))
+
+        PlaceItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+}

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentItemDifferTest.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentItemDifferTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.moment
+
+import com.benasher44.uuid.uuid4
+import com.chrynan.uri.core.Uri
+import com.chrynan.uri.core.fromString
+import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
+import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMoment
+import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlinx.datetime.Instant
+import org.junit.Test
+
+class MomentItemDifferTest {
+    @Test
+    fun `Reports two moments with differing IDs as being different`() {
+        val one = FakeMoment(uuid4(), mutableListOf())
+        val another = FakeMoment(uuid4(), mutableListOf())
+
+        MomentItemDiffer.areItemsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two moments with the same ID as being same`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+
+        MomentItemDiffer.areItemsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two moments with identical content as being same content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two moments with differing timestamp as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+        one.update(LiteralTimestamp(Instant.DISTANT_FUTURE))
+        another.update(LiteralTimestamp(Instant.DISTANT_PAST))
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two moments with differing description as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+        one.update(TokenableString("Foo"))
+        another.update(TokenableString("Bar"))
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two moments with differing sentiment as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+        one.update(Sentiment(1.0F))
+        another.update(Sentiment(0.0F))
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two moments with differing places as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+        one.update(FakePlace())
+        another.update(FakePlace())
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two moments with differing attachments as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeMoment(id, mutableListOf())
+        val another = FakeMoment(id, mutableListOf())
+        one.update(listOf(Uri.fromString("https://foo.bar")))
+        another.update(listOf(Uri.fromString("https://fizz.buzz")))
+
+        MomentItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+}

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/story/StoryItemDifferTest.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/story/StoryItemDifferTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.story
+
+import com.benasher44.uuid.uuid4
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import org.junit.Test
+
+class StoryItemDifferTest {
+
+    @Test
+    fun `Reports two stories with differing IDs as being different`() {
+        val one = FakeStory(uuid4(), mutableListOf())
+        val another = FakeStory(uuid4(), mutableListOf())
+
+        StoryItemDiffer.areItemsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two stories with the same ID as being same`() {
+        val id = uuid4()
+        val one = FakeStory(id, mutableListOf())
+        val another = FakeStory(id, mutableListOf())
+
+        StoryItemDiffer.areItemsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two stories with identical content as being same content-wise`() {
+        val id = uuid4()
+        val one = FakeStory(id, mutableListOf())
+        val another = FakeStory(id, mutableListOf())
+
+        StoryItemDiffer.areContentsTheSame(one, another).shouldBeTrue()
+    }
+
+    @Test
+    fun `Reports two stories with differing title as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeStory(id, mutableListOf())
+        val another = FakeStory(id, mutableListOf())
+        one.update("Foo")
+        another.update("Bar")
+
+        StoryItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two stories with differing synopsis as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeStory(id, mutableListOf())
+        val another = FakeStory(id, mutableListOf())
+        one.update(TokenableString("Foo"))
+        another.update(TokenableString("Bar"))
+
+        StoryItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+
+    @Test
+    fun `Reports two stories with differing moments as being different content-wise`() {
+        val id = uuid4()
+        val one = FakeStory(id, mutableListOf())
+        val another = FakeStory(id, mutableListOf())
+        one.new().update(TokenableString("Foo"))
+        another.new().update(TokenableString("Bar"))
+
+        StoryItemDiffer.areContentsTheSame(one, another).shouldBeFalse()
+    }
+}

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewPresenter.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewPresenter.kt
@@ -27,6 +27,7 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.LayoutParams.MATCH_PARENT
 import androidx.recyclerview.widget.RecyclerView.LayoutParams.WRAP_CONTENT
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.roundToInt
 
 class RecyclerViewPresenter<T : Any>(
@@ -38,6 +39,7 @@ class RecyclerViewPresenter<T : Any>(
 ) : Presenter<Iterable<T>> {
 
     private val adapter: Adapter<T> by lazy { Adapter(viewFactory, viewRenderer, differ) }
+    private val isSetupRequired: AtomicBoolean = AtomicBoolean(true)
 
     constructor(recyclerView: RecyclerView) : this(
         recyclerView,
@@ -80,7 +82,7 @@ class RecyclerViewPresenter<T : Any>(
     ) : this(recyclerView, layoutManager, viewFactory, viewRenderer, NaiveItemDiffer())
 
     override fun present(thing: Iterable<T>) {
-        setupRecyclerView()
+        if (isSetupRequired.getAndSet(false)) setupRecyclerView()
         adapter.submitList(thing.toList())
     }
 

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewPresenterTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/widget/RecyclerViewPresenterTest.kt
@@ -21,6 +21,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.runner.AndroidJUnit4
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.spyk
+import io.mockk.verify
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
@@ -28,7 +30,7 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(AndroidJUnit4::class)
 class RecyclerViewPresenterTest {
 
-    private val recyclerView = RecyclerView(RuntimeEnvironment.getApplication())
+    private val recyclerView = spyk(RecyclerView(RuntimeEnvironment.getApplication()))
     private val strings = listOf("Foo", "Bar", "Fizz", "Buzz")
     private val presenter = RecyclerViewPresenter<String>(recyclerView)
 
@@ -38,5 +40,12 @@ class RecyclerViewPresenterTest {
         recyclerView.layoutManager.shouldNotBeNull()
         recyclerView.adapter.shouldNotBeNull()
         recyclerView.adapter!!.itemCount.shouldBe(strings.size)
+    }
+
+    @Test
+    fun `Shares the adapter and layout manager for all presentation calls`() {
+        repeat(10) { presenter.present(strings) }
+        verify(exactly = 1) { recyclerView.setAdapter(any()) }
+        verify(exactly = 1) { recyclerView.setLayoutManager(any()) }
     }
 }


### PR DESCRIPTION
### What has changed

#### Optimization of `RecyclerViewPresenter`

The class no longer attempts to reset both the adapter and layout manager of its RecyclerView with every call to present().

#### Proper item differ objects

Proper item diffing logic has been defined for stories, moments, and places, with checks appropriate for each class. In comparison to NaiveItemDiffer, these methods will provide a more accurate assessment.

### Why it was changed

These glitches were degrading the UX.