### PR TITLE
Enable moment description paraphrasing

### DIFF
--- a/app-android-journal3/build.gradle.kts
+++ b/app-android-journal3/build.gradle.kts
@@ -35,6 +35,7 @@ android {
             signingConfig = signingConfigs.getByName("debug")
             applicationIdSuffix = "canary"
             buildConfigField("String", "KEY_HERE_API", "\"${System.getenv("DEBUG_KEY_HERE_API")}\"")
+            buildConfigField("String", "KEY_OAI_API", "\"${System.getenv("DEBUG_KEY_OAI_API")}\"")
         }
         release {
             isDebuggable = false
@@ -43,6 +44,7 @@ android {
             signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
             buildConfigField("String", "KEY_HERE_API", "\"${System.getenv("RELEASE_KEY_HERE_API")}\"")
+            buildConfigField("String", "KEY_OAI_API", "\"${System.getenv("RELEASE_KEY_OAI_API")}\"")
         }
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -30,6 +30,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
+import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
 import kotlinx.datetime.Clock
 import java.util.concurrent.Executor
 import kotlin.time.Duration
@@ -45,6 +46,7 @@ abstract class Journal3Application : Application() {
     abstract val timestampDecor: Timestamp.Decor
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst
+    abstract val paraphraser: Paraphraser
     abstract val clock: Clock
     abstract val backgroundExecutor: Executor
     abstract val foregroundExecutor: Executor

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -61,6 +61,8 @@ import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.here.HereNearbyPlaces
 import com.hadisatrio.libs.kotlin.io.SchemeWiseSources
 import com.hadisatrio.libs.kotlin.io.filesystem.FileSystemSources
+import com.hadisatrio.libs.kotlin.paraphrase.OpenAiParaphraser
+import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.datetime.Clock
@@ -74,6 +76,8 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
 class RealJournal3Application : Journal3Application() {
+
+    private val httpClient = HttpClient()
 
     override val places: Places by lazy {
         HereNearbyPlaces(
@@ -214,6 +218,17 @@ class RealJournal3Application : Journal3Application() {
             }
             TfliteSentimentAnalyst(modelFile)
         }
+    }
+
+    override val paraphraser: Paraphraser by lazy {
+        OpenAiParaphraser(
+            prompt = "You will be provided with diary entry drafts, " +
+                "and your task is to refine their quality without changing too much " +
+                "of the author's tonality and writing style. Don't use overly complex words unless " +
+                "you saw the author use them.",
+            apiKey = BuildConfig.KEY_OAI_API,
+            httpClient = httpClient,
+        )
     }
 
     override val clock: Clock by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -42,13 +42,13 @@ import com.hadisatrio.libs.android.foundation.widget.EditTextInputEventSource
 import com.hadisatrio.libs.android.foundation.widget.PhotoCaptureEventSource
 import com.hadisatrio.libs.android.foundation.widget.PhotoSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
+import com.hadisatrio.libs.android.foundation.widget.SwitchSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.TextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.android.io.uri.toAndroidUri
 import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
-import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -133,7 +133,7 @@ class EditAMomentActivity : AppCompatActivity() {
                 ),
                 ViewClickEventSource(
                     view = findViewById(R.id.commit_button),
-                    eventFactory = { CompletionEvent() }
+                    eventFactory = { SelectionEvent("action", "commit") }
                 ),
                 PlaceSelectionEventSource(
                     triggerView = findViewById(R.id.place_selector_button),
@@ -149,6 +149,11 @@ class EditAMomentActivity : AppCompatActivity() {
                 SliderSelectionEventSource(
                     slider = findViewById(R.id.sentiment_slider),
                     selectionKind = "sentiment"
+                ),
+                SwitchSelectionEventSource(
+                    switch = findViewById(R.id.paraphrase_switch),
+                    offEventFactory = { SelectionEvent("action", "disable_paraphrasing") },
+                    onEventFactory = { SelectionEvent("action", "enable_paraphrasing") }
                 ),
                 PhotoCaptureEventSource(
                     triggerView = findViewById(R.id.photo_capturer_button),

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -183,6 +183,7 @@ class EditAMomentActivity : AppCompatActivity() {
                 eventSource = eventSource,
                 eventSink = eventSink,
                 analyst = journal3Application.sentimentAnalyst,
+                paraphraser = journal3Application.paraphraser,
                 clock = journal3Application.clock
             )
         )

--- a/app-android-journal3/src/main/res/drawable/ic16_paraphrase.xml
+++ b/app-android-journal3/src/main/res/drawable/ic16_paraphrase.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,9l1.25,-2.75L23,5l-2.75,-1.25L19,1l-1.25,2.75L15,5l2.75,1.25L19,9zM11.5,9.5L9,4 6.5,9.5 1,12l5.5,2.5L9,20l2.5,-5.5L17,12l-5.5,-2.5zM19,15l-1.25,2.75L15,19l2.75,1.25L19,23l1.25,-2.75L23,19l-2.75,-1.25L19,15z" />
+
+</vector>

--- a/app-android-journal3/src/main/res/layout/activity_edit_a_moment.xml
+++ b/app-android-journal3/src/main/res/layout/activity_edit_a_moment.xml
@@ -33,9 +33,9 @@
             android:id="@+id/description_text_layout"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            android:layout_marginBottom="@dimen/margin"
+            android:layout_marginBottom="@dimen/gutter"
             android:hint="Description"
-            app:layout_constraintBottom_toTopOf="@id/photo_grid"
+            app:layout_constraintBottom_toTopOf="@id/paraphrase_switch"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
@@ -47,6 +47,17 @@
                 android:gravity="top" />
 
         </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.materialswitch.MaterialSwitch
+            android:id="@+id/paraphrase_switch"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin"
+            android:text="Paraphrase"
+            app:layout_constraintBottom_toTopOf="@id/photo_grid"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:thumbIcon="@drawable/ic16_paraphrase" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/photo_grid"

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -35,6 +35,8 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.fake.FakePresenter
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.SelfPopulatingPlaces
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlaces
+import com.hadisatrio.libs.kotlin.paraphrase.DumbParaphraser
+import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.datetime.Clock
 import java.util.concurrent.Executor
@@ -53,6 +55,7 @@ class FakeJournal3Application : Journal3Application() {
     override val globalEventSource: EventSource by lazy { EventHub(MutableSharedFlow(extraBufferCapacity = 1)) }
     override val timestampDecor: Timestamp.Decor by lazy { Timestamp.Decor { it } }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
+    override val paraphraser: Paraphraser by lazy { DumbParaphraser }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }
     override val clock: Clock by lazy { Clock.System }
     override val backgroundExecutor: Executor by lazy { Executors.newFixedThreadPool(2) }

--- a/app-kmm-journal3/build.gradle.kts
+++ b/app-kmm-journal3/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
                 api(project(":lib-kmm-io"))
                 api(project(":lib-kmm-json"))
                 api(project(":lib-kmm-geography"))
+                api(project(":lib-kmm-paraphrase"))
                 api(Dependencies.Commons.DATETIME)
             }
         }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMoment.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
+
+class DescriptionParaphrasingMoment(
+    private val paraphraser: Paraphraser,
+    private val origin: MomentInEdit
+) : MomentInEdit by origin {
+
+    override fun commit() {
+        val original = origin.description.toString()
+        val paraphrased = paraphraser.paraphrase(original)
+        origin.update(TokenableString(paraphrased))
+        origin.commit()
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMomentTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class DescriptionParaphrasingMomentTest {
+
+    private val paraphraser: Paraphraser = mockk(relaxed = true)
+    private val origin: MomentInEdit = mockk(relaxed = true)
+    private val moment: DescriptionParaphrasingMoment = DescriptionParaphrasingMoment(paraphraser, origin)
+
+    @Test
+    fun `Updates the origin's description with the paraphrased string upon commit`() {
+        every { origin.description }.returns(TokenableString("foo"))
+        every { paraphraser.paraphrase("foo") }.returns("bar")
+        moment.commit()
+        verify { paraphraser.paraphrase("foo") }
+        verify { origin.update(TokenableString("bar")) }
+        verify { origin.commit() }
+    }
+}

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/SwitchSelectionEventSource.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/widget/SwitchSelectionEventSource.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.widget
+
+import androidx.appcompat.widget.SwitchCompat
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import reactivecircus.flowbinding.android.widget.checkedChanges
+
+class SwitchSelectionEventSource(
+    private val switch: SwitchCompat,
+    private val offEventFactory: Event.Factory,
+    private val onEventFactory: Event.Factory,
+) : EventSource {
+
+    override fun events(): Flow<Event> {
+        return switch.checkedChanges().map { isChecked ->
+            if (isChecked) {
+                onEventFactory.create()
+            } else {
+                offEventFactory.create()
+            }
+        }
+    }
+}

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/widget/SwitchSelectionEventSourceTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/widget/SwitchSelectionEventSourceTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.widget
+
+import androidx.activity.ComponentActivity
+import androidx.appcompat.widget.SwitchCompat
+import androidx.test.runner.AndroidJUnit4
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEvent
+import io.kotest.matchers.maps.shouldContain
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+
+@RunWith(AndroidJUnit4::class)
+class SwitchSelectionEventSourceTest {
+
+    private val activityController = Robolectric.buildActivity(ComponentActivity::class.java)
+    private val activity = activityController.get()
+    private val switch = SwitchCompat(activity)
+    private val offEventFactory = Event.Factory { FakeEvent("value" to "off") }
+    private val onEventFactory = Event.Factory { FakeEvent("value" to "on") }
+    private val eventSource = SwitchSelectionEventSource(switch, offEventFactory, onEventFactory)
+
+    @Test
+    fun `Produces Event from the 'off' factory when switch is toggled off`() = runTest {
+        val events = mutableListOf<Event>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            eventSource.events().toList(events)
+        }
+
+        switch.isChecked = false
+
+        val description = events.last().describe()
+        description.shouldContain("value" to "off")
+        collectJob.cancel()
+    }
+
+    @Test
+    fun `Produces Event from the 'on' factory when switch is toggled on`() = runTest {
+        val events = mutableListOf<Event>()
+        val collectJob = launch(UnconfinedTestDispatcher()) {
+            eventSource.events().toList(events)
+        }
+
+        switch.isChecked = true
+
+        val description = events.last().describe()
+        description.shouldContain("value" to "on")
+        collectJob.cancel()
+    }
+}

--- a/lib-kmm-paraphrase/build.gradle.kts
+++ b/lib-kmm-paraphrase/build.gradle.kts
@@ -1,0 +1,82 @@
+apply("$rootDir/gradle/script-ext.gradle")
+
+plugins {
+    kotlin("multiplatform")
+    id("com.android.library")
+    id("org.jetbrains.kotlinx.kover")
+    id("io.gitlab.arturbosch.detekt")
+}
+
+kotlin {
+    jvm()
+    androidTarget()
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                api(project(":lib-kmm-json"))
+                api(Dependencies.Network.KTOR)
+            }
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+                implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
+                implementation(Dependencies.TestDouble.MOCKK)
+                implementation(Dependencies.TestDouble.KTOR_MOCK_ENGINE)
+            }
+        }
+        val androidMain by getting
+        val androidUnitTest by getting
+    }
+}
+
+android {
+    compileSdk = Dependencies.AndroidSdk.COMPILE
+    sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
+    defaultConfig {
+        minSdk = Dependencies.AndroidSdk.MINIMUM
+        targetSdk = Dependencies.AndroidSdk.TARGET
+    }
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+kover {
+    filters {
+        classes {
+            excludes += listOf("*Fake*", "*Test")
+        }
+    }
+    verify {
+        onCheck.set(true)
+        rule {
+            isEnabled = true
+            name = "Branch coverage must exceed 90%"
+            target = kotlinx.kover.api.VerificationTarget.ALL
+
+            bound {
+                minValue = 90
+                counter = kotlinx.kover.api.CounterType.BRANCH
+                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+            }
+        }
+    }
+}
+
+detekt {
+    autoCorrect = true
+    source = files(
+        "src/commonMain/kotlin",
+        "src/commonTest/kotlin",
+        "src/androidMain/kotlin",
+        "src/androidUnitTest/kotlin"
+    )
+}
+
+dependencies {
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
+}

--- a/lib-kmm-paraphrase/src/androidMain/AndroidManifest.xml
+++ b/lib-kmm-paraphrase/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<manifest package="com.hadisatrio.libs.android.paraphrase" />

--- a/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/DumbParaphraser.kt
+++ b/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/DumbParaphraser.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.paraphrase
+
+object DumbParaphraser : Paraphraser {
+
+    override fun paraphrase(text: String): String {
+        return text
+    }
+}

--- a/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/OpenAiParaphraser.kt
+++ b/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/OpenAiParaphraser.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.paraphrase
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.request.url
+import io.ktor.http.ContentType
+import io.ktor.http.URLBuilder
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import okio.IOException
+
+class OpenAiParaphraser(
+    private val prompt: String,
+    private val apiKey: String,
+    private val httpClient: HttpClient
+) : Paraphraser {
+
+    private val urlBuilder: URLBuilder by lazy {
+        URLBuilder("https://api.openai.com/v1/chat/completions")
+    }
+
+    override fun paraphrase(text: String): String {
+        val messages = mutableListOf<JsonElement>()
+        messages.add(message("system", prompt))
+        messages.add(message("user", text))
+
+        val body = mutableMapOf<String, JsonElement>()
+        body["model"] = JsonPrimitive("gpt-3.5-turbo")
+        body["messages"] = JsonArray(messages)
+
+        val requestBuilder = HttpRequestBuilder()
+        requestBuilder.url(urlBuilder.build())
+        requestBuilder.contentType(ContentType.Application.Json)
+        requestBuilder.bearerAuth(apiKey)
+        requestBuilder.setBody(JsonObject(body).toString())
+
+        val response = runBlocking { httpClient.post(requestBuilder) }
+        if (!response.status.isSuccess()) throw IOException(response.status.toString())
+        val responseBody = runBlocking { response.body<String>() }
+        val responseObject = Json.parseToJsonElement(responseBody).jsonObject
+        val choices = responseObject["choices"]!!.jsonArray
+        val message = choices.first().jsonObject["message"]!!.jsonObject
+
+        return message["content"]!!.jsonPrimitive.content
+    }
+
+    private fun message(role: String, content: String): JsonObject {
+        val message = mutableMapOf<String, JsonElement>()
+        message["role"] = JsonPrimitive(role)
+        message["content"] = JsonPrimitive(content)
+        return JsonObject(message)
+    }
+}

--- a/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/Paraphraser.kt
+++ b/lib-kmm-paraphrase/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/paraphrase/Paraphraser.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.paraphrase
+
+interface Paraphraser {
+    fun paraphrase(text: String): String
+}

--- a/lib-kmm-paraphrase/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/paraphrase/DumbParaphraserTest.kt
+++ b/lib-kmm-paraphrase/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/paraphrase/DumbParaphraserTest.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.paraphrase
+
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class DumbParaphraserTest {
+
+    @Test
+    fun `Paraphrases the given text by simply returning it`() {
+        DumbParaphraser.paraphrase("foo").shouldBe("foo")
+    }
+}

--- a/lib-kmm-paraphrase/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/paraphrase/OpenAiParaphraserTest.kt
+++ b/lib-kmm-paraphrase/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/paraphrase/OpenAiParaphraserTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.paraphrase
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.utils.io.errors.IOException
+import kotlin.test.Test
+
+class OpenAiParaphraserTest {
+
+    private val prompt = "You're a helpful assistant."
+    private val apiKey = "wCHWXm4g%Nkg@79z8bMzkg@79z8bMz"
+    private val httpClientEngine = clientEngine(shouldFail = false)
+    private val paraphraser = OpenAiParaphraser(
+        prompt = prompt,
+        apiKey = apiKey,
+        httpClient = HttpClient(httpClientEngine)
+    )
+
+    @Test
+    fun `Paraphrases the given text according to the server response`() {
+        paraphraser.paraphrase("foo").shouldBe("Bar.")
+    }
+
+    @Test
+    fun `Throws IOException when server is unable to respond`() {
+        val paraphraser = OpenAiParaphraser(
+            prompt = prompt,
+            apiKey = apiKey,
+            httpClient = HttpClient(clientEngine(shouldFail = true))
+        )
+
+        shouldThrow<IOException> { paraphraser.paraphrase("foo") }
+    }
+
+    private fun clientEngine(shouldFail: Boolean): MockEngine {
+        return MockEngine { request ->
+            val url = request.url
+            url.toString().shouldStartWith("https://api.openai.com/v1/chat/completions")
+            request.headers["Authorization"].shouldBe("Bearer $apiKey")
+            request.body.contentType.shouldBe(ContentType.Application.Json)
+
+            if (shouldFail) {
+                respondError(HttpStatusCode.InternalServerError)
+            } else {
+                respondOk(
+                    """
+                      {
+                        "id": "chatcmpl-7qlXeGmXtKxrB9VqQ9l6hihZNjvfB",
+                        "object": "chat.completion",
+                        "created": 1692810162,
+                        "model": "gpt-3.5-turbo-0613",
+                        "choices": [
+                          {
+                            "index": 0,
+                            "message": {
+                              "role": "assistant",
+                              "content": "Bar."
+                            },
+                            "finish_reason": "stop"
+                          }
+                        ],
+                        "usage": {
+                          "prompt_tokens": 80,
+                          "completion_tokens": 44,
+                          "total_tokens": 124
+                        }
+                      }
+                    """.trimIndent()
+                )
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,7 @@ rootProject.name = "Journal3"
 include ':app-android-journal3'
 include ':app-kmm-journal3'
 include ':lib-kmm-geography'
+include ':lib-kmm-paraphrase'
 include ':lib-kmm-json'
 include ':lib-kmm-io'
 include ':lib-kmm-foundation'


### PR DESCRIPTION
### What has changed

#### `lib-kmm-paraphrase`

A new module has been added to host object classes centered around text paraphrasing. There are 2 implementations so far: `OpenAiParaphraser` which rely on OpenAi's `chat` endpoint to paraphrase a given string and `DumbParaphraser` which would just do nothing. 

#### Paraphrasing decor for `MomentInEdit`s

Leveraging a `Paraphraser`, `DescriptionParaphrasingMoment` will attempt to replace the description it has with a paraphrased version upon `commit()`-ing the change.

#### Toggle handling within `EditAMomentUseCase`

While useful, the user may choose to disable paraphrasing altogether. To handle this, `EditAMomentUseCase` have been updated with an internal state to represent this "toggle" as well as mechanism to handle the relevant `Event`s around it.

#### A new `EventSource` for `SwitchCompat`

We added `SwitchSelectionEventSource` to cater to the needs of adding a `MaterialSwitch` to the moment editor screen.

### Why it was changed

Paraphrasing decrease the barrier for users to record their moments. They won't have to worry about grammatical errors or other writing issues and focus solely on pouring their thoughts.