### PR TITLE
Fix crashes reported within the place selector

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -192,6 +192,7 @@ class RealJournal3Application : Journal3Application() {
     override val globalEventSink: EventSink by lazy {
         EventSinks(
             ActivityRoutingEventSink(currentActivity),
+            SentryExceptionalLog,
             SystemLog("Journal3")
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/SentryExceptionalLog.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/SentryExceptionalLog.kt
@@ -15,18 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation.event
+package com.hadisatrio.apps.android.journal3
 
-import java.lang.Exception
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.ExceptionalEvent
+import io.sentry.Sentry
 
-class ExceptionalEvent(
-    val exception: Exception
-) : Event() {
+object SentryExceptionalLog : EventSink {
 
-    override fun describeInternally(): Map<String, String> {
-        return mapOf(
-            "message" to exception.message.toString(),
-            "stacktrace" to exception.stackTraceToString(),
-        )
+    override fun sink(event: Event) {
+        if (event !is ExceptionalEvent) return
+        Sentry.captureException(event.exception)
     }
 }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -63,18 +63,15 @@ class SelectAPlaceActivity : AppCompatActivity() {
             view.findViewById<TextView>(R.id.name_label).text = item.name
         }
 
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.backgroundExecutor,
-            origin = AdaptingPresenter(
-                adapter = { it.toList() },
-                origin = ExecutorDispatchingPresenter(
-                    executor = journal3Application.foregroundExecutor,
-                    origin = RecyclerViewPresenter(
-                        recyclerView = findViewById(R.id.places_list),
-                        viewFactory = viewFactory,
-                        viewRenderer = viewRenderer,
-                        differ = PlaceItemDiffer
-                    ),
+        AdaptingPresenter(
+            adapter = { it.toList() },
+            origin = ExecutorDispatchingPresenter(
+                executor = journal3Application.foregroundExecutor,
+                origin = RecyclerViewPresenter(
+                    recyclerView = findViewById(R.id.places_list),
+                    viewFactory = viewFactory,
+                    viewRenderer = viewRenderer,
+                    differ = PlaceItemDiffer
                 )
             )
         )
@@ -123,6 +120,7 @@ class SelectAPlaceActivity : AppCompatActivity() {
             origin = SelectAPlaceUseCase(
                 places = journal3Application.places,
                 presenter = presenter,
+                modalPresenter = journal3Application.modalPresenter,
                 eventSource = eventSource,
                 eventSink = eventSink
             )

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -23,6 +23,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.ExceptionalEvent
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
@@ -51,13 +52,14 @@ class SelectAPlaceUseCase(
         observeEvents()
     }
 
-    @Suppress("SwallowedException", "TooGenericExceptionCaught")
+    @Suppress("TooGenericExceptionCaught")
     private fun presentState() {
         try {
             presenter.present(places)
         } catch (e: Exception) {
             val modal = BinaryConfirmationModal("presentation_retrial_confirmation")
             modalPresenter.present(modal)
+            eventSink.sink(ExceptionalEvent(e))
         }
     }
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -24,6 +24,10 @@ import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
+import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -35,6 +39,7 @@ import kotlinx.coroutines.runBlocking
 class SelectAPlaceUseCase(
     private val places: Places,
     private val presenter: Presenter<Places>,
+    private val modalPresenter: Presenter<Modal>,
     private val eventSource: EventSource,
     private val eventSink: EventSink,
 ) : UseCase {
@@ -46,8 +51,14 @@ class SelectAPlaceUseCase(
         observeEvents()
     }
 
+    @Suppress("SwallowedException", "TooGenericExceptionCaught")
     private fun presentState() {
-        presenter.present(places)
+        try {
+            presenter.present(places)
+        } catch (e: Exception) {
+            val modal = BinaryConfirmationModal("presentation_retrial_confirmation")
+            modalPresenter.present(modal)
+        }
     }
 
     private fun observeEvents() = runBlocking {
@@ -60,6 +71,8 @@ class SelectAPlaceUseCase(
     private suspend fun handleEvent(event: Event) {
         when (event) {
             is SelectionEvent -> handleSelection(event)
+            is ModalApprovalEvent -> handleModalApproval(event)
+            is ModalDismissalEvent -> handleModalDismissal(event)
             is CancellationEvent -> handleCancellation()
         }
     }
@@ -75,6 +88,16 @@ class SelectAPlaceUseCase(
                 completionEvents.emit(CompletionEvent())
             }
         }
+    }
+
+    private fun handleModalApproval(event: ModalApprovalEvent) {
+        if (event.modalKind != "presentation_retrial_confirmation") return
+        presentState()
+    }
+
+    private suspend fun handleModalDismissal(event: ModalDismissalEvent) {
+        if (event.modalKind != "presentation_retrial_confirmation") return
+        completionEvents.emit(CompletionEvent())
     }
 
     private suspend fun handleCancellation() {

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ExceptionalEvent.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ExceptionalEvent.kt
@@ -15,23 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.android.foundation.os
+package com.hadisatrio.libs.kotlin.foundation.event
 
-import android.util.Log
-import com.hadisatrio.libs.kotlin.foundation.event.Event
-import com.hadisatrio.libs.kotlin.foundation.event.EventSink
-import com.hadisatrio.libs.kotlin.foundation.event.ExceptionalEvent
+import java.lang.Exception
 
-class SystemLog(
-    private val logTag: String
-) : EventSink {
+class ExceptionalEvent(
+    private val exception: Exception
+) : Event() {
 
-    override fun sink(event: Event) {
-        val message = "Event observed: ${event.describe()}"
-        if (event is ExceptionalEvent) {
-            Log.e(logTag, message)
-        } else {
-            Log.d(logTag, message)
-        }
+    override fun describeInternally(): Map<String, String> {
+        return mapOf(
+            "message" to exception.message.toString(),
+            "stacktrace" to exception.stackTraceToString(),
+        )
     }
 }

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
@@ -74,7 +74,7 @@ class HereNearbyPlaces(
     private suspend fun iteratorFromHttp(coordinates: Coordinates): Iterator<HerePlace> {
         val url = urlBuilder.apply { parameters.append("at", coordinates.toString()) }.build()
         val response = httpClient.get(url)
-        if (!response.status.isSuccess()) throw IOException(response.status.toString())
+        if (!response.status.isSuccess()) throw IOException("HTTP ${response.status}: ${response.body<String>()}.")
         pastResponses[coordinates] = response
         return iteratorFromResponse(response)
     }


### PR DESCRIPTION
### What has changed

#### Exception handling

`SelectAPlaceUseCase` will now expect exceptions better while presenting. As we're dealing with an external system here, this is bound to happen. When such thing happen, it will then attempt to present a `Modal` prompting the user to retry instead of crashing the process.

#### Exception logging

To ensure we won't lose debugging information from exceptions, `ExceptionalEvent` was added to allow them to be piped into `EventSink`s. This capability is leveraged in two ways:

1. `SystemLog` will now print a `android.util.Log.e` whenever it's receiving an `ExceptionalEvent`.
2. `SentryExceptionalLog` (which got added in this changeset) will capture the exception and send it to our Sentry dashboard.

Like `SystemLog`, `SentryExceptionalLog` was added as part of the global `EventSink`; allowing it to serve the entirety of the application.

### Why it was changed

Because we have gotten reports of crash related to this on Sentry.
1. https://mrhadisatrio.sentry.io/issues/4488269691/?project=4505846177398784&query=&referrer=issue-stream&stream_index=2
2. https://mrhadisatrio.sentry.io/issues/4491109511/?project=4505846177398784&query=&referrer=issue-stream&stream_index=1