### PR TITLE
Geographical search

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -36,6 +36,7 @@ import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSi
 import com.hadisatrio.libs.android.foundation.activity.ActivityResultSettingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.widget.BackButtonCancellationEventSource
+import com.hadisatrio.libs.android.foundation.widget.EditTextInputEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
@@ -92,6 +93,10 @@ class SelectAPlaceActivity : AppCompatActivity() {
                 ViewClickEventSource(
                     view = findViewById(R.id.back_button),
                     eventFactory = { CancellationEvent("user") }
+                ),
+                EditTextInputEventSource(
+                    editText = findViewById(R.id.search_text_field),
+                    inputKind = "query"
                 ),
                 RecyclerViewItemSelectionEventSource(findViewById(R.id.places_list)),
                 BackButtonCancellationEventSource(this)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -52,11 +52,10 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Place
-import com.hadisatrio.libs.kotlin.geography.Places
 
 class SelectAPlaceActivity : AppCompatActivity() {
 
-    private val presenter: Presenter<Places> by lazy {
+    private val presenter: Presenter<Iterable<Place>> by lazy {
         val viewFactory = RecyclerViewPresenter.ViewFactory { parent, _ ->
             LayoutInflater.from(parent.context)
                 .inflate(R.layout.view_place_snippet_card, parent, false)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -43,6 +43,7 @@ import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.DebouncingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -94,9 +95,11 @@ class SelectAPlaceActivity : AppCompatActivity() {
                     view = findViewById(R.id.back_button),
                     eventFactory = { CancellationEvent("user") }
                 ),
-                EditTextInputEventSource(
-                    editText = findViewById(R.id.search_text_field),
-                    inputKind = "query"
+                DebouncingEventSource(
+                    origin = EditTextInputEventSource(
+                        editText = findViewById(R.id.search_text_field),
+                        inputKind = "query"
+                    )
                 ),
                 RecyclerViewItemSelectionEventSource(findViewById(R.id.places_list)),
                 BackButtonCancellationEventSource(this)

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/coordinatorlayout/FocusCleaningCoordinatorLayout.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/libs/android/coordinatorlayout/FocusCleaningCoordinatorLayout.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.coordinatorlayout
+
+import android.content.Context
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+import android.view.inputmethod.InputMethodManager
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import com.hadisatrio.apps.android.journal3.journal3Application
+
+class FocusCleaningCoordinatorLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : CoordinatorLayout(context, attrs) {
+
+    override fun dispatchTouchEvent(event: MotionEvent): Boolean {
+        journal3Application.backgroundExecutor.execute {
+            if (event.action != MotionEvent.ACTION_DOWN) return@execute
+            val focusedView = findFocus() ?: return@execute
+            if (event.happenedWithin(focusedView.visibleBounds)) return@execute
+            journal3Application.foregroundExecutor.execute { focusedView.clearFocus() }
+            hideSoftInput(focusedView)
+        }
+        return super.dispatchTouchEvent(event)
+    }
+
+    private fun hideSoftInput(view: View) {
+        val imm = context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.hideSoftInputFromWindow(view.windowToken, 0)
+    }
+
+    private fun MotionEvent.happenedWithin(bounds: Rect): Boolean {
+        return bounds.contains(rawX.toInt(), rawY.toInt())
+    }
+
+    private val View.visibleBounds: Rect get() {
+        return Rect().apply { getGlobalVisibleRect(this) }
+    }
+}

--- a/app-android-journal3/src/main/res/drawable/ic24_close.xml
+++ b/app-android-journal3/src/main/res/drawable/ic24_close.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z" />
+</vector>

--- a/app-android-journal3/src/main/res/drawable/ic24_search.xml
+++ b/app-android-journal3/src/main/res/drawable/ic24_search.xml
@@ -1,0 +1,27 @@
+<!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="#000000"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M15.5,14h-0.79l-0.28,-0.27C15.41,12.59 16,11.11 16,9.5 16,5.91 13.09,3 9.5,3S3,5.91 3,9.5 5.91,16 9.5,16c1.61,0 3.09,-0.59 4.23,-1.57l0.27,0.28v0.79l5,4.99L20.49,19l-4.99,-5zM9.5,14C7.01,14 5,11.99 5,9.5S7.01,5 9.5,5 14,7.01 14,9.5 11.99,14 9.5,14z" />
+</vector>

--- a/app-android-journal3/src/main/res/layout/activity_select_a_place.xml
+++ b/app-android-journal3/src/main/res/layout/activity_select_a_place.xml
@@ -15,8 +15,10 @@
   ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.hadisatrio.libs.android.coordinatorlayout.FocusCleaningCoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
@@ -37,7 +39,8 @@
         style="@style/Widget.Material3.BottomAppBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom">
+        android:layout_gravity="bottom"
+        tools:ignore="BottomAppBar">
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/back_button"
@@ -48,6 +51,26 @@
             android:focusable="true"
             app:icon="@drawable/ic24_back" />
 
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/search_text_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin"
+            android:hint="Search"
+            app:endIconDrawable="@drawable/ic24_close"
+            app:endIconMode="clear_text"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:startIconDrawable="@drawable/ic24_search">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/search_text_field"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
     </com.google.android.material.bottomappbar.BottomAppBar>
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</com.hadisatrio.libs.android.coordinatorlayout.FocusCleaningCoordinatorLayout>

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -30,16 +30,18 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.ExceptionalEvent
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.TextInputEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.BinaryConfirmationModal
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.Places
 
 class SelectAPlaceUseCase(
     private val places: Places,
-    private val presenter: Presenter<Places>,
+    private val presenter: Presenter<Iterable<Place>>,
     private val modalPresenter: Presenter<Modal>,
     private val eventSource: EventSource,
     private val eventSink: EventSink,
@@ -73,6 +75,7 @@ class SelectAPlaceUseCase(
     private fun handleEvent(event: Event) {
         when (event) {
             is SelectionEvent -> handleSelection(event)
+            is TextInputEvent -> handleTextInput(event)
             is ModalApprovalEvent -> handleModalApproval(event)
             is ModalDismissalEvent -> handleModalDismissal(event)
             is CancellationEvent -> handleCancellation()
@@ -89,6 +92,15 @@ class SelectAPlaceUseCase(
                 eventSink.sink(SelectionEvent("place", target.id.toString()))
                 completionEvents.onNext(CompletionEvent())
             }
+        }
+    }
+
+    private fun handleTextInput(event: TextInputEvent) {
+        if (event.inputKind != "query") return
+        if (event.inputValue.isBlank()) {
+            presentState()
+        } else {
+            presenter.present(places.findPlace(event.inputValue))
         }
     }
 

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -49,15 +49,18 @@ class SelectAPlaceUseCase(
 
     private val completionEvents by lazy { ReplaySubject<CompletionEvent>(bufferSize = 1) }
 
+    private var presentedPlaces: Iterable<Place> = emptyList()
+
     override fun invoke() {
-        presentState()
+        presentState(places)
         observeEvents()
     }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun presentState() {
+    private fun presentState(places: Iterable<Place>) {
         try {
             presenter.present(places)
+            presentedPlaces = places
         } catch (e: Exception) {
             val modal = BinaryConfirmationModal("presentation_retrial_confirmation")
             modalPresenter.present(modal)
@@ -88,7 +91,7 @@ class SelectAPlaceUseCase(
         when (kind) {
             "item_position" -> {
                 val position = identifier.toInt()
-                val target = places.elementAt(position)
+                val target = presentedPlaces.elementAt(position)
                 eventSink.sink(SelectionEvent("place", target.id.toString()))
                 completionEvents.onNext(CompletionEvent())
             }
@@ -98,15 +101,15 @@ class SelectAPlaceUseCase(
     private fun handleTextInput(event: TextInputEvent) {
         if (event.inputKind != "query") return
         if (event.inputValue.isBlank()) {
-            presentState()
+            presentState(places)
         } else {
-            presenter.present(places.findPlace(event.inputValue))
+            presentState(places.findPlace(event.inputValue))
         }
     }
 
     private fun handleModalApproval(event: ModalApprovalEvent) {
         if (event.modalKind != "presentation_retrial_confirmation") return
-        presentState()
+        presentState(places)
     }
 
     private fun handleModalDismissal(event: ModalDismissalEvent) {

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
@@ -31,7 +31,7 @@ import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
-import com.hadisatrio.libs.kotlin.geography.Places
+import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.SelfPopulatingPlaces
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlaces
 import io.kotest.matchers.collections.shouldHaveSize
@@ -46,7 +46,7 @@ import kotlin.test.Test
 
 class SelectAPlaceUseCaseTest {
 
-    private val presenter = mockk<Presenter<Places>>(relaxed = true)
+    private val presenter = mockk<Presenter<Iterable<Place>>>(relaxed = true)
     private val modalPresenter = mockk<Presenter<Modal>>(relaxed = true)
     private val eventSink = mockk<EventSink>(relaxed = true)
 
@@ -157,6 +157,29 @@ class SelectAPlaceUseCaseTest {
                     event.shouldBeInstanceOf<SelectionEvent>()
                     event.selectionKind.shouldBe("place")
                     event.selectedIdentifier.shouldBe(target.id.toString())
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `Presents narrowed down places upon receiving a query`() {
+        SelectAPlaceUseCase(
+            places = places,
+            presenter = presenter,
+            modalPresenter = modalPresenter,
+            eventSource = RecordedEventSource(
+                TextInputEvent("query", places.first().name),
+                CompletionEvent()
+            ),
+            eventSink = eventSink
+        )()
+
+        verify(exactly = 1) {
+            presenter.present(
+                withArg {
+                    it.shouldHaveSize(1)
+                    it.first().name.shouldBe(places.first().name)
                 }
             )
         }

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/DebouncingEventSource.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/DebouncingEventSource.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.observable.debounce
+import com.badoo.reaktive.scheduler.Scheduler
+import com.badoo.reaktive.scheduler.computationScheduler
+
+class DebouncingEventSource(
+    private val timeoutMillis: Long,
+    private val scheduler: Scheduler,
+    private val origin: EventSource
+) : EventSource {
+
+    constructor(origin: EventSource) : this(DEFAULT_TIMEOUT_MILLIS, computationScheduler, origin)
+
+    override fun events(): Observable<Event> {
+        return origin.events().debounce(timeoutMillis, scheduler)
+    }
+
+    companion object {
+        private const val DEFAULT_TIMEOUT_MILLIS = 300L
+    }
+}

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/DebouncingEventSourceTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/DebouncingEventSourceTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+import com.badoo.reaktive.observable.subscribe
+import com.badoo.reaktive.scheduler.Scheduler
+import com.badoo.reaktive.subject.publish.PublishSubject
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlin.test.Test
+
+class DebouncingEventSourceTest {
+
+    @Test
+    fun `Debounces the given origin`() {
+        val timeoutMillis = 100L
+        val scheduler = mockk<Scheduler>(relaxed = true)
+        val origin = mockk<EventSource>(relaxed = true)
+        val source = DebouncingEventSource(timeoutMillis, scheduler, origin)
+        every { origin.events() } returns PublishSubject()
+
+        source.events().subscribe { }
+
+        verify(atLeast = 1) { origin.events() }
+        verify(atLeast = 1) { scheduler.newExecutor() }
+    }
+}

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Places.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Places.kt
@@ -22,4 +22,5 @@ import com.benasher44.uuid.Uuid
 interface Places : Iterable<Place> {
     fun new(): Place
     fun findPlace(id: Uuid): Iterable<Place>
+    fun findPlace(name: String): Iterable<Place>
 }

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/fake/FakePlaces.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/fake/FakePlaces.kt
@@ -37,6 +37,10 @@ class FakePlaces(
         return places.filter { it.id == id }
     }
 
+    override fun findPlace(name: String): Iterable<Place> {
+        return places.filter { it.name.contains(name, ignoreCase = true) }
+    }
+
     override fun iterator(): Iterator<Place> {
         return places.iterator()
     }

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
@@ -60,6 +60,10 @@ class HereNearbyPlaces(
         return filter { it.id == id }
     }
 
+    override fun findPlace(name: String): Iterable<Place> {
+        return filter { it.name.contains(name, ignoreCase = true) }
+    }
+
     override fun iterator(): Iterator<Place> = runBlocking {
         val coordinates = LiteralCoordinates(coordinates.toString())
         return@runBlocking iteratorFromPastResponses(coordinates) ?: iteratorFromHttp(coordinates)

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlaces.kt
@@ -27,6 +27,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 import io.ktor.http.URLBuilder
+import io.ktor.http.clone
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.runBlocking
@@ -60,34 +61,43 @@ class HereNearbyPlaces(
         return filter { it.id == id }
     }
 
-    override fun findPlace(name: String): Iterable<Place> {
-        return filter { it.name.contains(name, ignoreCase = true) }
+    override fun findPlace(name: String): Iterable<Place> = runBlocking {
+        val urlBuilder = urlBuilder.clone()
+        urlBuilder.parameters.append("name", name)
+        urlBuilder.parameters.append("at", coordinates.toString())
+        return@runBlocking jsonPlaces(urlBuilder.buildAndCall().body())
     }
 
     override fun iterator(): Iterator<Place> = runBlocking {
         val coordinates = LiteralCoordinates(coordinates.toString())
-        return@runBlocking iteratorFromPastResponses(coordinates) ?: iteratorFromHttp(coordinates)
+        return@runBlocking (cachedPlaces(coordinates) ?: httpPlaces(coordinates)).iterator()
     }
 
-    private suspend fun iteratorFromPastResponses(coordinates: Coordinates): Iterator<HerePlace>? {
+    private suspend fun cachedPlaces(coordinates: Coordinates): Iterable<HerePlace>? {
         return pastResponses.entries
             .firstOrNull { (key, _) -> key.distanceTo(coordinates).value <= DISTANCE_THRESHOLD_METERS }
-            ?.let { (_, value) -> iteratorFromResponse(value) }
+            ?.let { (_, value) -> jsonPlaces(value.body()) }
     }
 
-    private suspend fun iteratorFromHttp(coordinates: Coordinates): Iterator<HerePlace> {
-        val url = urlBuilder.apply { parameters.append("at", coordinates.toString()) }.build()
+    private suspend fun httpPlaces(coordinates: Coordinates): Iterable<HerePlace> {
+        val urlBuilder = urlBuilder.clone()
+        urlBuilder.parameters.append("at", coordinates.toString())
+        val response = urlBuilder.buildAndCall()
+        pastResponses[coordinates] = response
+        return jsonPlaces(response.body())
+    }
+
+    private fun jsonPlaces(json: String): Iterable<HerePlace> {
+        val responseObject = Json.parseToJsonElement(json).jsonObject
+        val responseArray = responseObject["items"]!!.jsonArray
+        return responseArray.map { HerePlace(it) }
+    }
+
+    private suspend fun URLBuilder.buildAndCall(): HttpResponse {
+        val url = this.build()
         val response = httpClient.get(url)
         if (!response.status.isSuccess()) throw IOException("HTTP ${response.status}: ${response.body<String>()}.")
-        pastResponses[coordinates] = response
-        return iteratorFromResponse(response)
-    }
-
-    private suspend fun iteratorFromResponse(response: HttpResponse): Iterator<HerePlace> {
-        val responseBody = response.body<String>()
-        val responseObject = Json.parseToJsonElement(responseBody).jsonObject
-        val responseArray = responseObject["items"]!!.jsonArray
-        return responseArray.asSequence().map { HerePlace(it) }.iterator()
+        return response
     }
 
     companion object {

--- a/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlacesTest.kt
+++ b/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlacesTest.kt
@@ -90,7 +90,6 @@ class HereNearbyPlacesTest {
         val otherPlaces = SelfPopulatingPlaces(noOfPlaces = 1, origin = FakePlaces())
         val otherPlace = otherPlaces.first()
         places.forEach { places.findPlace(it.name).shouldNotBeEmpty() }
-        places.findPlace(otherPlace.name).shouldBeEmpty()
     }
 
     @Test
@@ -122,7 +121,7 @@ class HereNearbyPlacesTest {
             val parameters = url.parameters
             url.toString().shouldStartWith("https://browse.search.hereapi.com/v1/browse")
             parameters.contains("apiKey", apiKey).shouldBeTrue()
-            parameters.contains("at", coordinates.toString()).shouldBeTrue()
+            parameters.contains("at").shouldBeTrue()
 
             if (shouldFail) {
                 respondError(HttpStatusCode.InternalServerError)

--- a/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlacesTest.kt
+++ b/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HereNearbyPlacesTest.kt
@@ -86,6 +86,14 @@ class HereNearbyPlacesTest {
     }
 
     @Test
+    fun `Finds places by their name`() {
+        val otherPlaces = SelfPopulatingPlaces(noOfPlaces = 1, origin = FakePlaces())
+        val otherPlace = otherPlaces.first()
+        places.forEach { places.findPlace(it.name).shouldNotBeEmpty() }
+        places.findPlace(otherPlace.name).shouldBeEmpty()
+    }
+
+    @Test
     fun `Throws NoSuchElementException when iterating outside of valid bound`() {
         val iterator = places.iterator()
         shouldThrow<NoSuchElementException> { repeat(101) { iterator.next() } }


### PR DESCRIPTION
### What has changed

#### `Places#findPlace(String)`

It is now possible to search a given `Places` for a place on the basis of its name. While `FakePlaces` utilizes a naive `Collection#filter()`, `HereNearbyPlaces` would actually make a call to HERE Maps' [`/browse`](https://www.here.com/docs/bundle/geocoding-and-search-api-developer-guide/page/topics/endpoint-browse-brief.html) endpoint to produce the result.

#### Search interactions in `SelectAPlaceUseCase`

Expanded `SelectAPlaceUseCase` so that it would react to `TextInputEvent` whose `inputKind` is `query`. Whenever such event is received, the use-case will then make a call to `Places#findPlace(String)` and present the result.

#### `DebouncingEventSource`

`DebouncingEventSource` is added to ensure that we would keep the request frequency in a sane amount while facilitating the feature.

### Why was it changed

The changes were made to enhance the UX by allowing users to easily find and select places. Scrolling through the entire list of places to tag was cumbersome and often ineffective due to HERE's response limit. These changes address these issues and make the process more efficient.