### PR TITLE
Fix crashes in place selection and story editing flows

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -39,7 +39,6 @@ import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
-import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -87,7 +86,7 @@ class EditAStoryActivity : AppCompatActivity() {
                 ),
                 ViewClickEventSource(
                     view = findViewById(R.id.commit_button),
-                    eventFactory = { CompletionEvent() }
+                    eventFactory = { SelectionEvent("action", "commit") }
                 ),
                 ViewClickEventSource(
                     view = findViewById(R.id.delete_button),

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditAStoryUseCaseTest.kt
@@ -54,7 +54,7 @@ class EditAStoryUseCaseTest {
             eventSource = RecordedEventSource(
                 TextInputEvent("title", "Foo"),
                 TextInputEvent("synopsis", "Bar"),
-                CompletionEvent()
+                SelectionEvent("action", "commit")
             ),
             eventSink = mockk(relaxed = true)
         )()
@@ -79,7 +79,7 @@ class EditAStoryUseCaseTest {
                 ModalDismissalEvent("edit_cancellation_confirmation"),
                 TextInputEvent("title", "Fizz"),
                 TextInputEvent("synopsis", "Buzz"),
-                CompletionEvent()
+                SelectionEvent("action", "commit")
             ),
             eventSink = mockk(relaxed = true)
         )()
@@ -150,7 +150,7 @@ class EditAStoryUseCaseTest {
             eventSource = RecordedEventSource(
                 CancellationEvent("user"),
                 ModalApprovalEvent("edit_cancellation_confirmation"),
-                CompletionEvent()
+                SelectionEvent("action", "commit")
             ),
             eventSink = mockk(relaxed = true)
         )()


### PR DESCRIPTION
### What has changed

#### `HereNearbyPlaces` caches more data more effectively

The class will now cache search results in addition to the list it receives while fulfilling a call to its `iterator()` method. As a result, this change introduces new overhead for its `findPlace(Uuid)` method. To address this, a change has been made to cache `HerePlace` objects instead of raw `HttpResponse`s.

#### `EditAStoryUseCase` now persists and commits sequentially

To prevent race conditions when the user is trying to persist their edit, the use-case now ensures that it won't complete until the change has been successfully `commit()`-ed.

### Why it was changed

PR #187 missed covering the case wherein the user selects a place that exists only in the search results list. This led to [a crash](https://mrhadisatrio.sentry.io/share/issue/4ecf9e8c525f45e2a7b965c9d974c5a3/) when the moment editing use-case attempts to find said place.

The change to `EditAStoryUseCase` was made to resolve a locally-occurring crash.