### PR TITLE
Clean up common source sets

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -48,6 +48,7 @@ import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.android.foundation.modal.AlertDialogModalPresenter
 import com.hadisatrio.libs.android.foundation.os.SystemLog
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.geography.LocationManagerCoordinates
 import com.hadisatrio.libs.android.geography.PermissionAwareCoordinates
 import com.hadisatrio.libs.android.io.content.ContentResolverSources
@@ -56,7 +57,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.here.HereNearbyPlaces

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -27,12 +27,12 @@ import com.badoo.reaktive.scheduler.mainScheduler
 import com.google.android.material.navigation.NavigationBarView
 import com.hadisatrio.apps.android.journal3.story.ReflectionStoriesListFragment
 import com.hadisatrio.apps.android.journal3.story.UserStoriesListFragment
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.NavigationBarSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.android.viewpager2.SimpleFragmentPagerAdapter
 import com.hadisatrio.libs.android.viewpager2.SimpleFragmentPagerAdapter.FragmentFactory
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -32,15 +32,16 @@ import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.geography.SelectAPlaceUseCase
 import com.hadisatrio.libs.android.dimensions.dp
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.activity.ActivityResultSettingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.BackButtonCancellationEventSource
 import com.hadisatrio.libs.android.foundation.widget.EditTextInputEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.DebouncingEventSource
@@ -51,7 +52,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Place
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -22,11 +22,11 @@ import androidx.appcompat.app.AppCompatActivity
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.moment.DeleteMomentUseCase
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 
 class DeleteAMomentActivity : AppCompatActivity() {
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -39,10 +39,12 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.SentimentAnalyzingMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.UpdateDeferringMoment
 import com.hadisatrio.apps.kotlin.journal3.story.EditableMomentInStory
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.SliderFloatPresenter
 import com.hadisatrio.libs.android.foundation.material.SliderSelectionEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.BackButtonCancellationEventSource
 import com.hadisatrio.libs.android.foundation.widget.EditTextInputEventSource
 import com.hadisatrio.libs.android.foundation.widget.PhotoCaptureEventSource
@@ -52,7 +54,6 @@ import com.hadisatrio.libs.android.foundation.widget.SwitchSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.TextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
 import com.hadisatrio.libs.android.io.uri.toAndroidUri
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -62,7 +63,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -22,11 +22,11 @@ import androidx.appcompat.app.AppCompatActivity
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.story.DeleteStoryUseCase
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 
 class DeleteAStoryActivity : AppCompatActivity() {
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -30,13 +30,14 @@ import com.hadisatrio.apps.kotlin.journal3.story.EditAStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.EditableStoryInStories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.UpdateDeferringStory
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.BackButtonCancellationEventSource
 import com.hadisatrio.libs.android.foundation.widget.EditTextInputEventSource
 import com.hadisatrio.libs.android.foundation.widget.TextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -46,7 +47,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
@@ -37,9 +37,9 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.widget.RemoteTextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.RemoteViewsUpdatingPresenter
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.event.NoOpEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -40,13 +40,13 @@ import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
 import com.hadisatrio.libs.android.dimensions.GOLDEN_RATIO
 import com.hadisatrio.libs.android.dimensions.dp
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlin.math.roundToInt
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
@@ -31,8 +31,8 @@ import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.dimensions.dp
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -28,6 +28,7 @@ import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoriesPresenter
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
@@ -35,7 +36,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
 class UserStoriesListFragment : StoriesListFragment() {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -39,13 +39,14 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
 import com.hadisatrio.libs.android.dimensions.dp
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.RecyclerViewPresenter
 import com.hadisatrio.libs.android.foundation.widget.TextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
-import com.hadisatrio.libs.kotlin.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -55,7 +56,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 

--- a/app-kmm-journal3/build.gradle.kts
+++ b/app-kmm-journal3/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.REACTIVE_EXTENSIONS_TEST)
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestDouble.OKIO_FAKE_FS)

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaces.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaces.kt
@@ -25,7 +25,6 @@ import com.hadisatrio.libs.kotlin.geography.NullIsland
 import com.hadisatrio.libs.kotlin.geography.Place
 import okio.FileSystem
 import okio.Path
-import java.util.UUID
 
 class FilesystemMemorablePlaces(
     private val fileSystem: FileSystem,
@@ -53,7 +52,7 @@ class FilesystemMemorablePlaces(
         }
     }
 
-    override fun relevantTo(momentId: UUID): Iterable<Memorable> {
+    override fun relevantTo(momentId: Uuid): Iterable<Memorable> {
         return filter { it.relevantTo(momentId) }
     }
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCaseTest.kt
@@ -31,7 +31,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.datetime.Clock
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorablesTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorablesTest.kt
@@ -6,7 +6,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.fake.FakeMemorables
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
-import org.junit.Test
+import kotlin.test.Test
 
 class MergedMemorablesTest {
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMomentTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMomentTest.kt
@@ -31,15 +31,15 @@ import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.shouldBe
 import kotlinx.datetime.Instant
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class UpdateDeferringMomentTest {
 
     private lateinit var original: EditableMoment
     private lateinit var updateDeferring: UpdateDeferringMoment
 
-    @Before
+    @BeforeTest
     fun `Inits subjects`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, origin = FakeStories())
         original = stories.first().moments.first() as EditableMoment

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoryUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoryUseCaseTest.kt
@@ -32,7 +32,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 import io.mockk.verify
-import org.junit.Test
+import kotlin.test.Test
 
 class ShowStoryUseCaseTest {
 

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/UpdateDeferringStoryTest.kt
@@ -23,15 +23,15 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
-import org.junit.Before
-import org.junit.Test
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 
 class UpdateDeferringStoryTest {
 
     private lateinit var original: EditableStory
     private lateinit var updateDeferring: UpdateDeferringStory
 
-    @Before
+    @BeforeTest
     fun `Inits subjects`() {
         val stories = SelfPopulatingStories(noOfStories = 1, noOfMoments = 1, origin = FakeStories())
         original = stories.first() as EditableStory

--- a/lib-kmm-foundation/build.gradle.kts
+++ b/lib-kmm-foundation/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.REACTIVE_EXTENSIONS_TEST)
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestDouble.MOCKK)

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/ExecutorDispatchingUseCase.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/ExecutorDispatchingUseCase.kt
@@ -15,8 +15,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation
+package com.hadisatrio.libs.android.foundation
 
+import com.hadisatrio.libs.kotlin.foundation.UseCase
 import java.util.concurrent.Executor
 
 class ExecutorDispatchingUseCase(

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/presentation/ExecutorDispatchingPresenter.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/presentation/ExecutorDispatchingPresenter.kt
@@ -15,13 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation.concurrent
+package com.hadisatrio.libs.android.foundation.presentation
 
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import java.util.concurrent.Executor
 
-class CurrentThreadExecutor : Executor {
+class ExecutorDispatchingPresenter<T>(
+    private val executor: Executor,
+    private val origin: Presenter<T>
+) : Presenter<T> {
 
-    override fun execute(command: Runnable) {
-        command.run()
+    override fun present(thing: T) {
+        executor.execute { origin.present(thing) }
     }
 }

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/ExecutorDispatchingUseCaseTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/ExecutorDispatchingUseCaseTest.kt
@@ -15,25 +15,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation.presentation
+package com.hadisatrio.libs.android.foundation
 
-import com.hadisatrio.libs.kotlin.foundation.concurrent.CurrentThreadExecutor
+import com.hadisatrio.libs.android.foundation.concurrent.CurrentThreadExecutor
+import com.hadisatrio.libs.kotlin.foundation.UseCase
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import java.util.concurrent.Executor
 import kotlin.test.Test
 
-class ExecutorDispatchingPresenterTest {
+class ExecutorDispatchingUseCaseTest {
 
     private val executor: Executor = spyk(CurrentThreadExecutor())
-    private val origin: Presenter<Any> = mockk(relaxUnitFun = true)
-    private val presenter = ExecutorDispatchingPresenter(executor, origin)
+    private val origin: UseCase = mockk(relaxUnitFun = true)
+    private val useCase = ExecutorDispatchingUseCase(executor, origin)
 
     @Test
     fun `Forwards call to the origin on the given executor`() {
-        presenter.present("Foo")
+        useCase()
         verify(exactly = 1) { executor.execute(any()) }
-        verify(exactly = 1) { origin.present("Foo") }
+        verify(exactly = 1) { origin.invoke() }
     }
 }

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/concurrent/CurrentThreadExecutor.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/concurrent/CurrentThreadExecutor.kt
@@ -15,16 +15,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation.presentation
+package com.hadisatrio.libs.android.foundation.concurrent
 
 import java.util.concurrent.Executor
 
-class ExecutorDispatchingPresenter<T>(
-    private val executor: Executor,
-    private val origin: Presenter<T>
-) : Presenter<T> {
+class CurrentThreadExecutor : Executor {
 
-    override fun present(thing: T) {
-        executor.execute { origin.present(thing) }
+    override fun execute(command: Runnable) {
+        command.run()
     }
 }

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/presentation/ExecutorDispatchingPresenterTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/presentation/ExecutorDispatchingPresenterTest.kt
@@ -15,25 +15,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.libs.kotlin.foundation
+package com.hadisatrio.libs.android.foundation.presentation
 
-import com.hadisatrio.libs.kotlin.foundation.concurrent.CurrentThreadExecutor
+import com.hadisatrio.libs.android.foundation.concurrent.CurrentThreadExecutor
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
 import java.util.concurrent.Executor
 import kotlin.test.Test
 
-class ExecutorDispatchingUseCaseTest {
+class ExecutorDispatchingPresenterTest {
 
     private val executor: Executor = spyk(CurrentThreadExecutor())
-    private val origin: UseCase = mockk(relaxUnitFun = true)
-    private val useCase = ExecutorDispatchingUseCase(executor, origin)
+    private val origin: Presenter<Any> = mockk(relaxUnitFun = true)
+    private val presenter = ExecutorDispatchingPresenter(executor, origin)
 
     @Test
     fun `Forwards call to the origin on the given executor`() {
-        useCase()
+        presenter.present("Foo")
         verify(exactly = 1) { executor.execute(any()) }
-        verify(exactly = 1) { origin.invoke() }
+        verify(exactly = 1) { origin.present("Foo") }
     }
 }

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ExceptionalEvent.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ExceptionalEvent.kt
@@ -17,8 +17,6 @@
 
 package com.hadisatrio.libs.kotlin.foundation.event
 
-import java.lang.Exception
-
 class ExceptionalEvent(
     val exception: Exception
 ) : Event() {

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/ExecutorDispatchingUseCaseTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/ExecutorDispatchingUseCaseTest.kt
@@ -21,8 +21,8 @@ import com.hadisatrio.libs.kotlin.foundation.concurrent.CurrentThreadExecutor
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.Test
 import java.util.concurrent.Executor
+import kotlin.test.Test
 
 class ExecutorDispatchingUseCaseTest {
 

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/EventSinksTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/EventSinksTest.kt
@@ -19,7 +19,7 @@ package com.hadisatrio.libs.kotlin.foundation.event
 
 import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSink
 import io.kotest.matchers.shouldBe
-import org.junit.Test
+import kotlin.test.Test
 
 class EventSinksTest {
 

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/presentation/ExecutorDispatchingPresenterTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/presentation/ExecutorDispatchingPresenterTest.kt
@@ -21,8 +21,8 @@ import com.hadisatrio.libs.kotlin.foundation.concurrent.CurrentThreadExecutor
 import io.mockk.mockk
 import io.mockk.spyk
 import io.mockk.verify
-import org.junit.Test
 import java.util.concurrent.Executor
+import kotlin.test.Test
 
 class ExecutorDispatchingPresenterTest {
 

--- a/lib-kmm-geography/build.gradle.kts
+++ b/lib-kmm-geography/build.gradle.kts
@@ -25,7 +25,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestUtility.ROBOLECTRIC)
                 implementation(Dependencies.TestDouble.MOCKK)

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/NullIsland.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/NullIsland.kt
@@ -18,11 +18,11 @@
 package com.hadisatrio.libs.kotlin.geography
 
 import com.benasher44.uuid.Uuid
-import java.util.UUID
+import com.benasher44.uuid.uuidFrom
 
 object NullIsland : Place {
 
-    override val id: Uuid = UUID.fromString("00000000-0000-0000-0000-000000000000")
+    override val id: Uuid = uuidFrom("00000000-0000-0000-0000-000000000000")
 
     override val name: String = "Null Island"
 

--- a/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinatesTest.kt
+++ b/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinatesTest.kt
@@ -20,7 +20,6 @@ package com.hadisatrio.libs.kotlin.geography
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import java.lang.IllegalArgumentException
 import kotlin.test.Test
 
 class LiteralCoordinatesTest {

--- a/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HerePlaceTest.kt
+++ b/lib-kmm-geography/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/geography/here/HerePlaceTest.kt
@@ -17,6 +17,7 @@
 
 package com.hadisatrio.libs.kotlin.geography.here
 
+import com.benasher44.uuid.Uuid
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.serialization.decodeFromString
@@ -24,7 +25,6 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import java.util.UUID
 import kotlin.test.Test
 
 class HerePlaceTest {
@@ -60,7 +60,7 @@ class HerePlaceTest {
     @Test
     fun `Infers ID from the Here ID consistently`() {
         val lifemarkStreetJsonId = lifemarkStreetJson["id"]!!.jsonPrimitive.content
-        lifemarkStreet.id.shouldBe(UUID.nameUUIDFromBytes(lifemarkStreetJsonId.toByteArray()))
+        lifemarkStreet.id.shouldBe(Uuid.nameUUIDFromBytes(lifemarkStreetJsonId.toByteArray()))
         lifemarkStreet.id.shouldBe(lifemarkStreet.id)
         lifemarkStreet.id.shouldBe(otherLifemarkStreet.id)
     }

--- a/lib-kmm-io/build.gradle.kts
+++ b/lib-kmm-io/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestDouble.OKIO_FAKE_FS)
                 implementation(Dependencies.TestDouble.MOCKK)

--- a/lib-kmm-io/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/io/FileSystemSourcesTest.kt
+++ b/lib-kmm-io/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/io/FileSystemSourcesTest.kt
@@ -27,7 +27,6 @@ import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.fakefilesystem.FakeFileSystem
-import java.lang.IllegalArgumentException
 import kotlin.test.AfterTest
 import kotlin.test.Test
 

--- a/lib-kmm-json/build.gradle.kts
+++ b/lib-kmm-json/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestDouble.OKIO_FAKE_FS)
             }

--- a/lib-kmm-paraphrase/build.gradle.kts
+++ b/lib-kmm-paraphrase/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                implementation(kotlin("test"))
+                implementation(kotlin("test-junit"))
                 implementation(Dependencies.TestUtility.KOTEST_ASSERTIONS)
                 implementation(Dependencies.TestDouble.MOCKK)
                 implementation(Dependencies.TestDouble.KTOR_MOCK_ENGINE)


### PR DESCRIPTION
### What has changed

Common source code (ones in `commonMain/` and `commonTest/`) are now free of JVM imports.

### Why it was changed

Mostly for hygiene. We don't really have any problems as we do have JVM as one of the targets, but it's still an inappropriate thing to do.