### PR TITLE
Fix Kover misconfiguration

### DIFF
--- a/app-kmm-journal3/build.gradle.kts
+++ b/app-kmm-journal3/build.gradle.kts
@@ -48,23 +48,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,7 @@
 plugins {
     id("scripts.infrastructure")
-    id("org.ajoberstar.grgit").version("5.2.1")
-    id("org.jetbrains.dokka").version("1.9.10")
     id("org.jetbrains.kotlinx.kover").version("0.7.4")
     id("io.gitlab.arturbosch.detekt").version("1.23.3")
-    id("org.barfuin.gradle.jacocolog").version("3.1.0")
     id("org.sonarqube").version("4.0.0.2929")
 }
 
@@ -39,10 +36,6 @@ sonarqube {
         property("sonar.organization", "mrhadisatrio")
         property("sonar.host.url", "https://sonarcloud.io")
     }
-}
-
-tasks.dokkaHtmlMultiModule.configure {
-    outputDirectory.set(file("${rootProject.projectDir}/public"))
 }
 
 val clean by tasks.creating(Delete::class) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ buildscript {
         classpath("androidx.benchmark:benchmark-gradle-plugin:1.2.1")
         classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
         classpath("org.jfrog.buildinfo:build-info-extractor-gradle:5.1.10")
-        classpath("org.jetbrains.kotlinx:kover:0.6.1")
         classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,14 +16,6 @@ buildscript {
         mavenCentral()
         maven(url = "https://ajoberstar.org/bintray-backup/")
     }
-    dependencies {
-        classpath("com.android.tools.build:gradle:8.1.4")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
-        classpath("androidx.benchmark:benchmark-gradle-plugin:1.2.1")
-        classpath("org.jetbrains.dokka:dokka-gradle-plugin:1.9.10")
-        classpath("org.jfrog.buildinfo:build-info-extractor-gradle:5.1.10")
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3")
-    }
 }
 
 allprojects {

--- a/lib-kmm-foundation/build.gradle.kts
+++ b/lib-kmm-foundation/build.gradle.kts
@@ -63,23 +63,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }

--- a/lib-kmm-geography/build.gradle.kts
+++ b/lib-kmm-geography/build.gradle.kts
@@ -62,23 +62,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test*", "*Rule*")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }

--- a/lib-kmm-io/build.gradle.kts
+++ b/lib-kmm-io/build.gradle.kts
@@ -56,23 +56,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }

--- a/lib-kmm-json/build.gradle.kts
+++ b/lib-kmm-json/build.gradle.kts
@@ -47,23 +47,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }

--- a/lib-kmm-paraphrase/build.gradle.kts
+++ b/lib-kmm-paraphrase/build.gradle.kts
@@ -48,23 +48,24 @@ android {
     }
 }
 
-kover {
+koverReport {
     filters {
-        classes {
-            excludes += listOf("*Fake*", "*Test")
+        excludes {
+            classes("*Fake*", "*Test")
         }
     }
-    verify {
-        onCheck.set(true)
-        rule {
-            isEnabled = true
-            name = "Branch coverage must exceed 90%"
-            target = kotlinx.kover.api.VerificationTarget.ALL
+    defaults {
+        verify {
+            onCheck = true
+            rule("Branch coverage must exceed 90%") {
+                isEnabled = true
+                entity = kotlinx.kover.gradle.plugin.dsl.GroupingEntityType.APPLICATION
 
-            bound {
-                minValue = 90
-                counter = kotlinx.kover.api.CounterType.BRANCH
-                valueType = kotlinx.kover.api.VerificationValueType.COVERED_PERCENTAGE
+                bound {
+                    minValue = 90
+                    metric = kotlinx.kover.gradle.plugin.dsl.MetricType.BRANCH
+                    aggregation = kotlinx.kover.gradle.plugin.dsl.AggregationType.COVERED_PERCENTAGE
+                }
             }
         }
     }


### PR DESCRIPTION
### What has changed

#### Removal of legacy plugin declaration

Remove `buildscript.dependencies` from the root Gradle file. These are redundant given we have always have the `plugins` declaration block.

#### Migrate Kover configuration

Alter the way we configure Kover on each modules to follow the [migration guide](https://github.com/Kotlin/kotlinx-kover/blob/v0.7.0/docs/gradle-plugin/migrations/migration-to-0.7.0.md).

### Why it was changed

Because we have seen overall flakiness in [CI](https://github.com/MrHadiSatrio/Journal3/actions/runs/6945228204) and [PR Check](https://github.com/MrHadiSatrio/Journal3/actions/runs/6937555546/job/18871827979) actions stemming from Kover. As it turned out, the duplicated plugin declaration has shrouded the fact that we haven't done proper migration following #26.