### PR TITLE
Centralize standard decorations

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -47,6 +47,7 @@ abstract class Journal3Application : Application() {
     abstract val globalEventSource: EventSource
     abstract val timestampDecor: Decor<Timestamp>
     abstract val useCaseDecor: Decor<UseCase>
+    abstract val eventSourceDecor: Decor<EventSource>
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst
     abstract val paraphraser: Paraphraser

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -48,6 +48,7 @@ abstract class Journal3Application : Application() {
     abstract val timestampDecor: Decor<Timestamp>
     abstract val useCaseDecor: Decor<UseCase>
     abstract val eventSourceDecor: Decor<EventSource>
+    abstract fun <T> presenterDecor(): Decor<Presenter<T>>
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst
     abstract val paraphraser: Paraphraser

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -48,6 +48,7 @@ abstract class Journal3Application : Application() {
     abstract val timestampDecor: Decor<Timestamp>
     abstract val useCaseDecor: Decor<UseCase>
     abstract val eventSourceDecor: Decor<EventSource>
+    abstract val eventSinkDecor: Decor<EventSink>
     abstract fun <T> presenterDecor(): Decor<Presenter<T>>
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -26,6 +26,7 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.SentimentAnalyst
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.kotlin.foundation.Decor
+import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
@@ -45,6 +46,7 @@ abstract class Journal3Application : Application() {
     abstract val globalEventSink: EventSink
     abstract val globalEventSource: EventSource
     abstract val timestampDecor: Decor<Timestamp>
+    abstract val useCaseDecor: Decor<UseCase>
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst
     abstract val paraphraser: Paraphraser

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -25,6 +25,7 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.sentiment.SentimentAnalyst
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
+import com.hadisatrio.libs.kotlin.foundation.Decor
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
@@ -43,7 +44,7 @@ abstract class Journal3Application : Application() {
     abstract val currentActivity: CurrentActivity
     abstract val globalEventSink: EventSink
     abstract val globalEventSource: EventSource
-    abstract val timestampDecor: Timestamp.Decor
+    abstract val timestampDecor: Decor<Timestamp>
     abstract val inactivityAlertThreshold: Duration
     abstract val sentimentAnalyst: SentimentAnalyst
     abstract val paraphraser: Paraphraser

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -63,6 +63,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
+import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.here.HereNearbyPlaces
@@ -217,6 +218,15 @@ class RealJournal3Application : Journal3Application() {
 
     override val eventSourceDecor: Decor<EventSource> by lazy {
         Decor { SchedulingEventSource(mainScheduler, computationScheduler, it) }
+    }
+
+    override fun <T> presenterDecor(): Decor<Presenter<T>> {
+        return Decor {
+            ExecutorDispatchingPresenter(
+                journal3Application.backgroundExecutor,
+                PerfTrackingPresenter(clock, globalEventSink, it)
+            )
+        }
     }
 
     override val inactivityAlertThreshold: Duration by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -45,6 +45,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.apps.kotlin.journal3.story.filesystem.FilesystemStories
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
+import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.android.foundation.modal.AlertDialogModalPresenter
 import com.hadisatrio.libs.android.foundation.os.SystemLog
@@ -53,6 +54,7 @@ import com.hadisatrio.libs.android.geography.LocationManagerCoordinates
 import com.hadisatrio.libs.android.geography.PermissionAwareCoordinates
 import com.hadisatrio.libs.android.io.content.ContentResolverSources
 import com.hadisatrio.libs.kotlin.foundation.Decor
+import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -204,6 +206,10 @@ class RealJournal3Application : Journal3Application() {
 
     override val timestampDecor: Decor<Timestamp> by lazy {
         Decor { FormattedTimestamp("EEEE, d MMMM yyyy '·' hh:mm aa", it) }
+    }
+
+    override val useCaseDecor: Decor<UseCase> by lazy {
+        Decor { ExecutorDispatchingUseCase(backgroundExecutor, it) }
     }
 
     override val inactivityAlertThreshold: Duration by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -49,6 +49,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.filesystem.FilesystemStories
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
+import com.hadisatrio.libs.android.foundation.event.ExecutorDispatchingEventSink
 import com.hadisatrio.libs.android.foundation.modal.AlertDialogModalPresenter
 import com.hadisatrio.libs.android.foundation.os.SystemLog
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
@@ -218,6 +219,10 @@ class RealJournal3Application : Journal3Application() {
 
     override val eventSourceDecor: Decor<EventSource> by lazy {
         Decor { SchedulingEventSource(mainScheduler, computationScheduler, it) }
+    }
+
+    override val eventSinkDecor: Decor<EventSink> by lazy {
+        Decor { ExecutorDispatchingEventSink(backgroundExecutor, it) }
     }
 
     override fun <T> presenterDecor(): Decor<Presenter<T>> {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -52,6 +52,7 @@ import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPr
 import com.hadisatrio.libs.android.geography.LocationManagerCoordinates
 import com.hadisatrio.libs.android.geography.PermissionAwareCoordinates
 import com.hadisatrio.libs.android.io.content.ContentResolverSources
+import com.hadisatrio.libs.kotlin.foundation.Decor
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -201,8 +202,8 @@ class RealJournal3Application : Journal3Application() {
         EventHub(PublishSubject())
     }
 
-    override val timestampDecor: Timestamp.Decor by lazy {
-        Timestamp.Decor { FormattedTimestamp("EEEE, d MMMM yyyy '·' hh:mm aa", it) }
+    override val timestampDecor: Decor<Timestamp> by lazy {
+        Decor { FormattedTimestamp("EEEE, d MMMM yyyy '·' hh:mm aa", it) }
     }
 
     override val inactivityAlertThreshold: Duration by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -18,6 +18,8 @@
 package com.hadisatrio.apps.android.journal3
 
 import androidx.core.content.ContextCompat
+import com.badoo.reaktive.scheduler.computationScheduler
+import com.badoo.reaktive.scheduler.mainScheduler
 import com.badoo.reaktive.subject.publish.PublishSubject
 import com.google.android.material.color.DynamicColors
 import com.hadisatrio.apps.android.journal3.sentiment.TfliteSentimentAnalyst
@@ -59,6 +61,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
@@ -210,6 +213,10 @@ class RealJournal3Application : Journal3Application() {
 
     override val useCaseDecor: Decor<UseCase> by lazy {
         Decor { ExecutorDispatchingUseCase(backgroundExecutor, it) }
+    }
+
+    override val eventSourceDecor: Decor<EventSource> by lazy {
+        Decor { SchedulingEventSource(mainScheduler, computationScheduler, it) }
     }
 
     override val inactivityAlertThreshold: Duration by lazy {

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -27,7 +27,6 @@ import com.badoo.reaktive.scheduler.mainScheduler
 import com.google.android.material.navigation.NavigationBarView
 import com.hadisatrio.apps.android.journal3.story.ReflectionStoriesListFragment
 import com.hadisatrio.apps.android.journal3.story.UserStoriesListFragment
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.NavigationBarSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
@@ -84,9 +83,8 @@ class RootActivity : AppCompatActivity() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = StreamEventsUseCase(
+        journal3Application.useCaseDecor.apply(
+            StreamEventsUseCase(
                 eventSource = eventSource,
                 eventSink = journal3Application.globalEventSink
             )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -22,8 +22,6 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.viewpager2.widget.ViewPager2
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.google.android.material.navigation.NavigationBarView
 import com.hadisatrio.apps.android.journal3.story.ReflectionStoriesListFragment
 import com.hadisatrio.apps.android.journal3.story.UserStoriesListFragment
@@ -36,7 +34,6 @@ import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.StreamEventsUseCase
 
@@ -51,10 +48,8 @@ class RootActivity : AppCompatActivity() {
     }
 
     private val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -32,6 +32,7 @@ import com.hadisatrio.libs.android.viewpager2.SimpleFragmentPagerAdapter
 import com.hadisatrio.libs.android.viewpager2.SimpleFragmentPagerAdapter.FragmentFactory
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
@@ -77,11 +78,15 @@ class RootActivity : AppCompatActivity() {
         )
     }
 
+    private val eventSink: EventSink by lazy {
+        journal3Application.eventSinkDecor.apply(journal3Application.globalEventSink)
+    }
+
     private val useCase: UseCase by lazy {
         journal3Application.useCaseDecor.apply(
             StreamEventsUseCase(
                 eventSource = eventSource,
-                eventSink = journal3Application.globalEventSink
+                eventSink = eventSink
             )
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
@@ -25,6 +25,7 @@ import com.hadisatrio.apps.android.journal3.notification.NotificationChannel
 import com.hadisatrio.apps.kotlin.journal3.alert.AlertInactivityUseCase
 import com.hadisatrio.libs.android.foundation.modal.NotificationModalPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.NoOpEventSource
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 
 @Suppress("unused")
 class InactivityAlertingWork(
@@ -37,12 +38,14 @@ class InactivityAlertingWork(
         AlertInactivityUseCase(
             threshold = application.inactivityAlertThreshold,
             stories = application.stories,
-            presenter = NotificationModalPresenter(
-                context = context,
-                contentAdapter = InactivityAlertModalNotificationBuilderAdapter(
+            presenter = application.presenterDecor<Modal>().apply(
+                NotificationModalPresenter(
                     context = context,
-                    channel = NotificationChannel.ALERT_AND_REMINDERS
-                ),
+                    contentAdapter = InactivityAlertModalNotificationBuilderAdapter(
+                        context = context,
+                        channel = NotificationChannel.ALERT_AND_REMINDERS
+                    ),
+                )
             ),
             eventSource = application.eventSourceDecor.apply(NoOpEventSource),
             eventSink = application.globalEventSink

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
@@ -48,7 +48,7 @@ class InactivityAlertingWork(
                 )
             ),
             eventSource = application.eventSourceDecor.apply(NoOpEventSource),
-            eventSink = application.globalEventSink
+            eventSink = application.eventSinkDecor.apply(application.globalEventSink)
         )()
         return Result.success()
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/alert/InactivityAlertingWork.kt
@@ -33,9 +33,10 @@ class InactivityAlertingWork(
 ) : Worker(context, workerParams) {
 
     override fun doWork(): Result {
+        val application = context.journal3Application
         AlertInactivityUseCase(
-            threshold = context.journal3Application.inactivityAlertThreshold,
-            stories = context.journal3Application.stories,
+            threshold = application.inactivityAlertThreshold,
+            stories = application.stories,
             presenter = NotificationModalPresenter(
                 context = context,
                 contentAdapter = InactivityAlertModalNotificationBuilderAdapter(
@@ -43,8 +44,8 @@ class InactivityAlertingWork(
                     channel = NotificationChannel.ALERT_AND_REMINDERS
                 ),
             ),
-            eventSource = NoOpEventSource,
-            eventSink = context.journal3Application.globalEventSink
+            eventSource = application.eventSourceDecor.apply(NoOpEventSource),
+            eventSink = application.globalEventSink
         )()
         return Result.success()
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -63,14 +63,16 @@ class SelectAPlaceActivity : AppCompatActivity() {
             view.findViewById<TextView>(R.id.name_label).text = item.name
         }
 
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.foregroundExecutor,
-            origin = ListViewPresenter(
-                recyclerView = findViewById(R.id.places_list),
-                viewFactory = viewFactory,
-                viewRenderer = viewRenderer,
-                differ = PlaceItemDiffer,
-                backgroundExecutor = journal3Application.backgroundExecutor
+        journal3Application.presenterDecor<Iterable<Place>>().apply(
+            ExecutorDispatchingPresenter(
+                executor = journal3Application.foregroundExecutor,
+                origin = ListViewPresenter(
+                    recyclerView = findViewById(R.id.places_list),
+                    viewFactory = viewFactory,
+                    viewRenderer = viewRenderer,
+                    differ = PlaceItemDiffer,
+                    backgroundExecutor = journal3Application.backgroundExecutor
+                )
             )
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -24,8 +24,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.grzegorzojdana.spacingitemdecoration.Spacing
 import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
 import com.hadisatrio.apps.android.journal3.R
@@ -50,7 +48,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Place
@@ -79,10 +76,8 @@ class SelectAPlaceActivity : AppCompatActivity() {
     }
 
     private val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -32,7 +32,6 @@ import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.geography.SelectAPlaceUseCase
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.activity.ActivityResultSettingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
@@ -124,9 +123,8 @@ class SelectAPlaceActivity : AppCompatActivity() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = SelectAPlaceUseCase(
+        journal3Application.useCaseDecor.apply(
+            SelectAPlaceUseCase(
                 places = journal3Application.places,
                 presenter = presenter,
                 modalPresenter = journal3Application.modalPresenter,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -103,19 +103,21 @@ class SelectAPlaceActivity : AppCompatActivity() {
     }
 
     private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityResultSettingEventSink(
-                activity = this,
-                adapter = { event ->
-                    val values = mutableMapOf<String, Any>()
-                    if (event is SelectionEvent && event.selectionKind == "place") {
-                        values["place"] = event.selectedIdentifier
+        journal3Application.eventSinkDecor.apply(
+            EventSinks(
+                journal3Application.globalEventSink,
+                ActivityResultSettingEventSink(
+                    activity = this,
+                    adapter = { event ->
+                        val values = mutableMapOf<String, Any>()
+                        if (event is SelectionEvent && event.selectionKind == "place") {
+                            values["place"] = event.selectedIdentifier
+                        }
+                        values
                     }
-                    values
-                }
-            ),
-            ActivityCompletionEventSink(this)
+                ),
+                ActivityCompletionEventSink(this)
+            )
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -25,6 +25,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.DeleteMomentUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 
 class DeleteAMomentActivity : AppCompatActivity() {
 
@@ -35,9 +36,11 @@ class DeleteAMomentActivity : AppCompatActivity() {
             DeleteMomentUseCase(
                 momentId = uuidFrom(intent.getStringExtra("target_id")!!),
                 stories = journal3Application.stories,
-                presenter = ExecutorDispatchingPresenter(
-                    executor = journal3Application.foregroundExecutor,
-                    origin = journal3Application.modalPresenter
+                presenter = journal3Application.presenterDecor<Modal>().apply(
+                    ExecutorDispatchingPresenter(
+                        executor = journal3Application.foregroundExecutor,
+                        origin = journal3Application.modalPresenter
+                    )
                 ),
                 eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.moment.DeleteMomentUseCase
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -33,9 +32,8 @@ class DeleteAMomentActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = DeleteMomentUseCase(
+        journal3Application.useCaseDecor.apply(
+            DeleteMomentUseCase(
                 momentId = uuidFrom(intent.getStringExtra("target_id")!!),
                 stories = journal3Application.stories,
                 presenter = ExecutorDispatchingPresenter(
@@ -50,6 +48,6 @@ class DeleteAMomentActivity : AppCompatActivity() {
                     ActivityCompletionEventSink(this)
                 )
             )
-        )()
+        )
     }
 }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -25,7 +25,6 @@ import com.hadisatrio.apps.kotlin.journal3.moment.DeleteMomentUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
-import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 
 class DeleteAMomentActivity : AppCompatActivity() {
 
@@ -40,7 +39,7 @@ class DeleteAMomentActivity : AppCompatActivity() {
                     executor = journal3Application.foregroundExecutor,
                     origin = journal3Application.modalPresenter
                 ),
-                eventSource = EventSources(
+                eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource
                 ),
                 eventSink = EventSinks(

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -45,9 +45,11 @@ class DeleteAMomentActivity : AppCompatActivity() {
                 eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource
                 ),
-                eventSink = EventSinks(
-                    journal3Application.globalEventSink,
-                    ActivityCompletionEventSink(this)
+                eventSink = journal3Application.eventSinkDecor.apply(
+                    EventSinks(
+                        journal3Application.globalEventSink,
+                        ActivityCompletionEventSink(this)
+                    )
                 )
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -39,7 +39,6 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.SentimentAnalyzingMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.UpdateDeferringMoment
 import com.hadisatrio.apps.kotlin.journal3.story.EditableMomentInStory
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.SliderFloatPresenter
@@ -183,9 +182,8 @@ class EditAMomentActivity : AppCompatActivity() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = EditAMomentUseCase(
+        journal3Application.useCaseDecor.apply(
+            EditAMomentUseCase(
                 moment = SentimentAnalyzingMoment(
                     analyst = journal3Application.sentimentAnalyst,
                     origin = ClockRespectingMoment(

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -172,9 +172,11 @@ class EditAMomentActivity : AppCompatActivity() {
     }
 
     private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityCompletionEventSink(this)
+        journal3Application.eventSinkDecor.apply(
+            EventSinks(
+                journal3Application.globalEventSink,
+                ActivityCompletionEventSink(this)
+            )
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -23,8 +23,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.bumptech.glide.Glide
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.datetime.TimestampSelectionEventSource
@@ -59,7 +57,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -114,10 +111,8 @@ class EditAMomentActivity : AppCompatActivity() {
     }
 
     private val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -69,42 +69,44 @@ class EditAMomentActivity : AppCompatActivity() {
     }
 
     private val presenter: Presenter<Moment> by lazy {
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.foregroundExecutor,
-            origin = Presenters(
-                AdaptingPresenter(
-                    origin = TimestampSelectorButtonPresenter(findViewById(R.id.timestamp_selector_button)),
-                    adapter = { moment -> moment.timestamp }
-                ),
-                AdaptingPresenter(
-                    origin = TextViewStringPresenter(findViewById(R.id.place_selector_button)),
-                    adapter = { moment -> moment.place.name }
-                ),
-                AdaptingPresenter(
-                    origin = TextViewStringPresenter(findViewById(R.id.description_text_field)),
-                    adapter = { moment -> moment.description.toString() }
-                ),
-                AdaptingPresenter(
-                    origin = SliderFloatPresenter(findViewById(R.id.sentiment_slider)),
-                    adapter = { moment -> moment.sentiment.value }
-                ),
-                AdaptingPresenter(
-                    origin = RecyclerViewPresenter(
-                        recyclerView = photoGrid,
-                        layoutManager = GridLayoutManager(this, PHOTO_GRID_SPAN_COUNT),
-                        viewFactory = { parent, _ ->
-                            ImageView(parent.context).apply {
-                                layoutParams = RecyclerView.LayoutParams(
-                                    photoGrid.measuredHeight,
-                                    photoGrid.measuredHeight
-                                )
-                            }
-                        },
-                        viewRenderer = { view, item ->
-                            Glide.with(view).load(item.toAndroidUri()).centerCrop().into(view as ImageView)
-                        }
+        journal3Application.presenterDecor<Moment>().apply(
+            ExecutorDispatchingPresenter(
+                executor = journal3Application.foregroundExecutor,
+                origin = Presenters(
+                    AdaptingPresenter(
+                        origin = TimestampSelectorButtonPresenter(findViewById(R.id.timestamp_selector_button)),
+                        adapter = { moment -> moment.timestamp }
                     ),
-                    adapter = { moment -> moment.attachments }
+                    AdaptingPresenter(
+                        origin = TextViewStringPresenter(findViewById(R.id.place_selector_button)),
+                        adapter = { moment -> moment.place.name }
+                    ),
+                    AdaptingPresenter(
+                        origin = TextViewStringPresenter(findViewById(R.id.description_text_field)),
+                        adapter = { moment -> moment.description.toString() }
+                    ),
+                    AdaptingPresenter(
+                        origin = SliderFloatPresenter(findViewById(R.id.sentiment_slider)),
+                        adapter = { moment -> moment.sentiment.value }
+                    ),
+                    AdaptingPresenter(
+                        origin = RecyclerViewPresenter(
+                            recyclerView = photoGrid,
+                            layoutManager = GridLayoutManager(this, PHOTO_GRID_SPAN_COUNT),
+                            viewFactory = { parent, _ ->
+                                ImageView(parent.context).apply {
+                                    layoutParams = RecyclerView.LayoutParams(
+                                        photoGrid.measuredHeight,
+                                        photoGrid.measuredHeight
+                                    )
+                                }
+                            },
+                            viewRenderer = { view, item ->
+                                Glide.with(view).load(item.toAndroidUri()).centerCrop().into(view as ImageView)
+                            }
+                        ),
+                        adapter = { moment -> moment.attachments }
+                    )
                 )
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -45,9 +45,11 @@ class DeleteAStoryActivity : AppCompatActivity() {
                 eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource
                 ),
-                eventSink = EventSinks(
-                    journal3Application.globalEventSink,
-                    ActivityCompletionEventSink(this)
+                eventSink = journal3Application.eventSinkDecor.apply(
+                    EventSinks(
+                        journal3Application.globalEventSink,
+                        ActivityCompletionEventSink(this)
+                    )
                 )
             )
         )()

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -25,7 +25,6 @@ import com.hadisatrio.apps.kotlin.journal3.story.DeleteStoryUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
-import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 
 class DeleteAStoryActivity : AppCompatActivity() {
 
@@ -40,7 +39,7 @@ class DeleteAStoryActivity : AppCompatActivity() {
                     executor = journal3Application.foregroundExecutor,
                     origin = journal3Application.modalPresenter
                 ),
-                eventSource = EventSources(
+                eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource
                 ),
                 eventSink = EventSinks(

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -25,6 +25,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.DeleteStoryUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 
 class DeleteAStoryActivity : AppCompatActivity() {
 
@@ -35,9 +36,11 @@ class DeleteAStoryActivity : AppCompatActivity() {
             DeleteStoryUseCase(
                 storyId = uuidFrom(intent.getStringExtra("target_id")!!),
                 stories = journal3Application.stories,
-                presenter = ExecutorDispatchingPresenter(
-                    executor = journal3Application.foregroundExecutor,
-                    origin = journal3Application.modalPresenter
+                presenter = journal3Application.presenterDecor<Modal>().apply(
+                    ExecutorDispatchingPresenter(
+                        executor = journal3Application.foregroundExecutor,
+                        origin = journal3Application.modalPresenter
+                    )
                 ),
                 eventSource = journal3Application.eventSourceDecor.apply(
                     journal3Application.globalEventSource

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/DeleteAStoryActivity.kt
@@ -22,7 +22,6 @@ import androidx.appcompat.app.AppCompatActivity
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.story.DeleteStoryUseCase
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -33,9 +32,8 @@ class DeleteAStoryActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = DeleteStoryUseCase(
+        journal3Application.useCaseDecor.apply(
+            DeleteStoryUseCase(
                 storyId = uuidFrom(intent.getStringExtra("target_id")!!),
                 stories = journal3Application.stories,
                 presenter = ExecutorDispatchingPresenter(

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -30,7 +30,6 @@ import com.hadisatrio.apps.kotlin.journal3.story.EditAStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.EditableStoryInStories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.UpdateDeferringStory
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
@@ -117,9 +116,8 @@ class EditAStoryActivity : AppCompatActivity() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = EditAStoryUseCase(
+        journal3Application.useCaseDecor.apply(
+            EditAStoryUseCase(
                 story = UpdateDeferringStory(
                     origin = EditableStoryInStories(
                         storyId = intent.getUuidExtra("target_id"),

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -49,16 +49,18 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 class EditAStoryActivity : AppCompatActivity() {
 
     private val presenter: Presenter<Story> by lazy {
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.foregroundExecutor,
-            origin = Presenters(
-                AdaptingPresenter(
-                    origin = TextViewStringPresenter(findViewById(R.id.title_text_field)),
-                    adapter = StoryStringAdapter("title")
-                ),
-                AdaptingPresenter(
-                    origin = TextViewStringPresenter(findViewById(R.id.synopsis_text_field)),
-                    adapter = StoryStringAdapter("synopsis")
+        journal3Application.presenterDecor<Story>().apply(
+            ExecutorDispatchingPresenter(
+                executor = journal3Application.foregroundExecutor,
+                origin = Presenters(
+                    AdaptingPresenter(
+                        origin = TextViewStringPresenter(findViewById(R.id.title_text_field)),
+                        adapter = StoryStringAdapter("title")
+                    ),
+                    AdaptingPresenter(
+                        origin = TextViewStringPresenter(findViewById(R.id.synopsis_text_field)),
+                        adapter = StoryStringAdapter("synopsis")
+                    )
                 )
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -106,9 +106,11 @@ class EditAStoryActivity : AppCompatActivity() {
     }
 
     private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityCompletionEventSink(this)
+        journal3Application.eventSinkDecor.apply(
+            EventSinks(
+                journal3Application.globalEventSink,
+                ActivityCompletionEventSink(this)
+            )
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -20,8 +20,6 @@ package com.hadisatrio.apps.android.journal3.story
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.id.getUuidExtra
 import com.hadisatrio.apps.android.journal3.journal3Application
@@ -43,7 +41,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -68,10 +65,8 @@ class EditAStoryActivity : AppCompatActivity() {
     }
 
     private val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
@@ -83,7 +83,7 @@ class PositiveReflectionsWidgetProvider : AppWidgetProvider() {
                     Presenter(application, widgetId, widgetManager, views)
                 ),
                 eventSource = application.eventSourceDecor.apply(NoOpEventSource),
-                eventSink = application.globalEventSink
+                eventSink = application.eventSinkDecor.apply(application.globalEventSink)
             )
         )
         useCase()

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
@@ -37,7 +37,6 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.widget.RemoteTextViewStringPresenter
 import com.hadisatrio.libs.android.foundation.widget.RemoteViewsUpdatingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.NoOpEventSource
@@ -61,9 +60,8 @@ class PositiveReflectionsWidgetProvider : AppWidgetProvider() {
     ) {
         val application = context.journal3Application
         val views = RemoteViews(context.packageName, R.layout.widget_moment)
-        val useCase = ExecutorDispatchingUseCase(
-            executor = application.backgroundExecutor,
-            origin = ShowStoriesUseCase(
+        val useCase = application.useCaseDecor.apply(
+            ShowStoriesUseCase(
                 stories = InitDeferringStories {
                     FakeStories(
                         Reflection(

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
@@ -79,7 +79,9 @@ class PositiveReflectionsWidgetProvider : AppWidgetProvider() {
                         )
                     )
                 },
-                presenter = Presenter(application, widgetId, widgetManager, views),
+                presenter = application.presenterDecor<Stories>().apply(
+                    Presenter(application, widgetId, widgetManager, views)
+                ),
                 eventSource = application.eventSourceDecor.apply(NoOpEventSource),
                 eventSink = application.globalEventSink
             )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/PositiveReflectionsWidgetProvider.kt
@@ -80,7 +80,7 @@ class PositiveReflectionsWidgetProvider : AppWidgetProvider() {
                     )
                 },
                 presenter = Presenter(application, widgetId, widgetManager, views),
-                eventSource = NoOpEventSource,
+                eventSource = application.eventSourceDecor.apply(NoOpEventSource),
                 eventSink = application.globalEventSink
             )
         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -22,8 +22,6 @@ import android.view.LayoutInflater
 import android.widget.TextView
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.grzegorzojdana.spacingitemdecoration.Spacing
 import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
 import com.hadisatrio.apps.android.journal3.R
@@ -46,7 +44,6 @@ import com.hadisatrio.libs.android.foundation.widget.recyclerview.ViewRenderer
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -118,10 +115,8 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
     }
 
     override val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -45,7 +45,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlin.math.roundToInt
 
@@ -90,23 +89,18 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
             (view.getTag(R.id.presenter_view_tag) as Presenter<Iterable<Moment>>).present(item.moments)
         }
 
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.backgroundExecutor,
-            origin = PerfTrackingPresenter(
-                clock = journal3Application.clock,
-                eventSink = journal3Application.globalEventSink,
-                origin = CachingStoriesPresenter(
-                    origin = ExecutorDispatchingPresenter(
-                        executor = journal3Application.foregroundExecutor,
-                        origin = AdaptingPresenter(
-                            adapter = { stories -> stories },
-                            origin = ListViewPresenter(
-                                recyclerView = storiesListView,
-                                viewFactory = itemViewFactory,
-                                viewRenderer = itemViewRenderer,
-                                differ = StoryItemDiffer,
-                                backgroundExecutor = journal3Application.backgroundExecutor
-                            )
+        journal3Application.presenterDecor<Stories>().apply(
+            CachingStoriesPresenter(
+                origin = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = AdaptingPresenter(
+                        adapter = { stories -> stories },
+                        origin = ListViewPresenter(
+                            recyclerView = storiesListView,
+                            viewFactory = itemViewFactory,
+                            viewRenderer = itemViewRenderer,
+                            differ = StoryItemDiffer,
+                            backgroundExecutor = journal3Application.backgroundExecutor
                         )
                     )
                 )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
@@ -51,9 +51,11 @@ abstract class StoriesListFragment : Fragment() {
     abstract val stories: Stories
 
     private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityCompletionEventSink(requireActivity())
+        journal3Application.eventSinkDecor.apply(
+            EventSinks(
+                journal3Application.globalEventSink,
+                ActivityCompletionEventSink(requireActivity())
+            )
         )
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
@@ -31,7 +31,6 @@ import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -59,9 +58,8 @@ abstract class StoriesListFragment : Fragment() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = ShowStoriesUseCase(
+        journal3Application.useCaseDecor.apply(
+            ShowStoriesUseCase(
                 stories = stories,
                 presenter = presenter,
                 eventSource = eventSource,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -33,7 +33,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
 class UserStoriesListFragment : StoriesListFragment() {
@@ -43,30 +42,25 @@ class UserStoriesListFragment : StoriesListFragment() {
     }
 
     override val presenter: Presenter<Stories> by lazy {
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.backgroundExecutor,
-            PerfTrackingPresenter(
-                clock = journal3Application.clock,
-                eventSink = journal3Application.globalEventSink,
-                origin = CachingStoriesPresenter(
-                    origin = ExecutorDispatchingPresenter(
-                        executor = journal3Application.foregroundExecutor,
-                        origin = AdaptingPresenter(
-                            adapter = { stories -> stories },
-                            origin = ListViewPresenter(
-                                recyclerView = storiesListView,
-                                viewFactory = { parent, _ ->
-                                    LayoutInflater.from(parent.context)
-                                        .inflate(R.layout.view_story_snippet_card, parent, false)
-                                },
-                                viewRenderer = { view, item ->
-                                    view.findViewById<TextView>(R.id.title_label).text = item.title
-                                    view.findViewById<TextView>(R.id.synopsis_label).text =
-                                        item.synopsis.toString()
-                                },
-                                differ = StoryItemDiffer,
-                                backgroundExecutor = journal3Application.backgroundExecutor
-                            )
+        journal3Application.presenterDecor<Stories>().apply(
+            CachingStoriesPresenter(
+                origin = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = AdaptingPresenter(
+                        adapter = { stories -> stories },
+                        origin = ListViewPresenter(
+                            recyclerView = storiesListView,
+                            viewFactory = { parent, _ ->
+                                LayoutInflater.from(parent.context)
+                                    .inflate(R.layout.view_story_snippet_card, parent, false)
+                            },
+                            viewRenderer = { view, item ->
+                                view.findViewById<TextView>(R.id.title_label).text = item.title
+                                view.findViewById<TextView>(R.id.synopsis_label).text =
+                                    item.synopsis.toString()
+                            },
+                            differ = StoryItemDiffer,
+                            backgroundExecutor = journal3Application.backgroundExecutor
                         )
                     )
                 )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -20,8 +20,6 @@ package com.hadisatrio.apps.android.journal3.story
 import android.view.LayoutInflater
 import android.widget.TextView
 import androidx.lifecycle.Lifecycle
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
@@ -34,7 +32,6 @@ import com.hadisatrio.libs.android.foundation.widget.recyclerview.RecyclerViewIt
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
@@ -78,10 +75,8 @@ class UserStoriesListFragment : StoriesListFragment() {
     }
 
     override val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -39,7 +39,6 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.ExecutorDispatchingUseCase
 import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
@@ -160,9 +159,8 @@ class ViewStoryActivity : AppCompatActivity() {
     }
 
     private val useCase: UseCase by lazy {
-        ExecutorDispatchingUseCase(
-            executor = journal3Application.backgroundExecutor,
-            origin = ShowStoryUseCase(
+        journal3Application.useCaseDecor.apply(
+            ShowStoryUseCase(
                 storyId = uuidFrom(intent.getStringExtra("target_id")!!),
                 stories = journal3Application.stories,
                 presenter = presenter,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -53,7 +53,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
-import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
 
@@ -94,15 +93,15 @@ class ViewStoryActivity : AppCompatActivity() {
             )
         )
 
-        ExecutorDispatchingPresenter(
-            executor = journal3Application.backgroundExecutor,
-            origin = PerfTrackingPresenter(
-                clock = journal3Application.clock,
-                eventSink = eventSink,
-                origin = CachingStoryPresenter(
-                    origin = ExecutorDispatchingPresenter(
-                        executor = journal3Application.foregroundExecutor,
-                        origin = Presenters(titlePresenter, synopsisPresenter, attachmentPresenter, momentsPresenter)
+        journal3Application.presenterDecor<Story>().apply(
+            CachingStoryPresenter(
+                origin = ExecutorDispatchingPresenter(
+                    executor = journal3Application.foregroundExecutor,
+                    origin = Presenters(
+                        titlePresenter,
+                        synopsisPresenter,
+                        attachmentPresenter,
+                        momentsPresenter
                     )
                 )
             )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -23,8 +23,6 @@ import android.view.LayoutInflater
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
-import com.badoo.reaktive.scheduler.computationScheduler
-import com.badoo.reaktive.scheduler.mainScheduler
 import com.benasher44.uuid.uuidFrom
 import com.grzegorzojdana.spacingitemdecoration.Spacing
 import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
@@ -53,7 +51,6 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
-import com.hadisatrio.libs.kotlin.foundation.event.SchedulingEventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.PerfTrackingPresenter
@@ -113,10 +110,8 @@ class ViewStoryActivity : AppCompatActivity() {
     }
 
     private val eventSource: EventSource by lazy {
-        SchedulingEventSource(
-            subscriptionScheduler = mainScheduler,
-            observationScheduler = computationScheduler,
-            origin = EventSources(
+        journal3Application.eventSourceDecor.apply(
+            EventSources(
                 journal3Application.globalEventSource,
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -146,9 +146,11 @@ class ViewStoryActivity : AppCompatActivity() {
     }
 
     private val eventSink: EventSink by lazy {
-        EventSinks(
-            journal3Application.globalEventSink,
-            ActivityCompletionEventSink(this)
+        journal3Application.eventSinkDecor.apply(
+            EventSinks(
+                journal3Application.globalEventSink,
+                ActivityCompletionEventSink(this)
+            )
         )
     }
 

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -26,6 +26,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStories
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
+import com.hadisatrio.libs.kotlin.foundation.Decor
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -53,7 +54,7 @@ class FakeJournal3Application : Journal3Application() {
     override val currentActivity: CurrentActivity by lazy { CurrentActivity(this) }
     override val globalEventSink: EventSink by lazy { FakeEventSink() }
     override val globalEventSource: EventSource by lazy { EventHub(PublishSubject()) }
-    override val timestampDecor: Timestamp.Decor by lazy { Timestamp.Decor { it } }
+    override val timestampDecor: Decor<Timestamp> by lazy { Decor<Timestamp> { it } }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val paraphraser: Paraphraser by lazy { DumbParaphraser }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -58,6 +58,7 @@ class FakeJournal3Application : Journal3Application() {
     override val timestampDecor: Decor<Timestamp> by lazy { Decor<Timestamp> { it } }
     override val useCaseDecor: Decor<UseCase> by lazy { Decor<UseCase> { it } }
     override val eventSourceDecor: Decor<EventSource> by lazy { Decor<EventSource> { it } }
+    override fun <T> presenterDecor(): Decor<Presenter<T>> = Decor { it }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val paraphraser: Paraphraser by lazy { DumbParaphraser }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -57,6 +57,7 @@ class FakeJournal3Application : Journal3Application() {
     override val globalEventSource: EventSource by lazy { EventHub(PublishSubject()) }
     override val timestampDecor: Decor<Timestamp> by lazy { Decor<Timestamp> { it } }
     override val useCaseDecor: Decor<UseCase> by lazy { Decor<UseCase> { it } }
+    override val eventSourceDecor: Decor<EventSource> by lazy { Decor<EventSource> { it } }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val paraphraser: Paraphraser by lazy { DumbParaphraser }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -58,6 +58,7 @@ class FakeJournal3Application : Journal3Application() {
     override val timestampDecor: Decor<Timestamp> by lazy { Decor<Timestamp> { it } }
     override val useCaseDecor: Decor<UseCase> by lazy { Decor<UseCase> { it } }
     override val eventSourceDecor: Decor<EventSource> by lazy { Decor<EventSource> { it } }
+    override val eventSinkDecor: Decor<EventSink> by lazy { Decor<EventSink> { it } }
     override fun <T> presenterDecor(): Decor<Presenter<T>> = Decor { it }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val paraphraser: Paraphraser by lazy { DumbParaphraser }

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -27,6 +27,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStories
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.kotlin.foundation.Decor
+import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventHub
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -55,6 +56,7 @@ class FakeJournal3Application : Journal3Application() {
     override val globalEventSink: EventSink by lazy { FakeEventSink() }
     override val globalEventSource: EventSource by lazy { EventHub(PublishSubject()) }
     override val timestampDecor: Decor<Timestamp> by lazy { Decor<Timestamp> { it } }
+    override val useCaseDecor: Decor<UseCase> by lazy { Decor<UseCase> { it } }
     override val inactivityAlertThreshold: Duration by lazy { 3.hours }
     override val paraphraser: Paraphraser by lazy { DumbParaphraser }
     override val sentimentAnalyst: SentimentAnalyst by lazy { DumbSentimentAnalyst }

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/event/ExecutorDispatchingEventSink.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/event/ExecutorDispatchingEventSink.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.event
+
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import java.util.concurrent.Executor
+
+class ExecutorDispatchingEventSink(
+    private val executor: Executor,
+    private val origin: EventSink
+) : EventSink {
+
+    override fun sink(event: Event) {
+        executor.execute { origin.sink(event) }
+    }
+}

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/event/ExecutorDispatchingEventSinkTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/event/ExecutorDispatchingEventSinkTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.foundation.event
+
+import com.hadisatrio.libs.android.foundation.concurrent.CurrentThreadExecutor
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEvent
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import java.util.concurrent.Executor
+import kotlin.test.Test
+
+class ExecutorDispatchingEventSinkTest {
+
+    private val executor: Executor = spyk(CurrentThreadExecutor())
+    private val origin: EventSink = mockk(relaxUnitFun = true)
+    private val eventSink = ExecutorDispatchingEventSink(executor, origin)
+
+    @Test
+    fun `Forwards call to the origin on the given executor`() {
+        val event = FakeEvent()
+        eventSink.sink(event)
+        verify(exactly = 1) { executor.execute(any()) }
+        verify(exactly = 1) { origin.sink(event) }
+    }
+}

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/Decor.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/Decor.kt
@@ -15,26 +15,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.hadisatrio.apps.kotlin.journal3.datetime
+package com.hadisatrio.libs.kotlin.foundation
 
-import kotlinx.datetime.Instant
-import kotlin.time.Duration
-
-interface Timestamp : Comparable<Timestamp> {
-
-    val value: Instant
-
-    fun toEpochMilliseconds(): Long {
-        return value.toEpochMilliseconds()
-    }
-
-    fun difference(other: Timestamp): Duration {
-        return this.value - other.value
-    }
-
-    override fun compareTo(other: Timestamp): Int {
-        return value.compareTo(other.value)
-    }
-
-    override fun toString(): String
+fun interface Decor<T> {
+    fun apply(thing: T): T
 }


### PR DESCRIPTION
### What has changed

Standard decorations (e.g., executor-dispatching, perf-tracking) are now provided as an application-level service.

### Why it was changed

Centralizing common decorations would help us in expanding functionalities (e.g., perf-tracking for presenters) as well as preventing mistakes (e.g., lack of executor-dispatching in `SelectAPlaceActivity`).