### PR TITLE
Fix crashes and UI glitches in screens with paginated content

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -52,6 +52,6 @@ class DeleteAMomentActivity : AppCompatActivity() {
                     )
                 )
             )
-        )
+        )()
     }
 }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -58,6 +58,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
@@ -116,10 +117,13 @@ class EditAMomentActivity : AppCompatActivity() {
         journal3Application.eventSourceDecor.apply(
             EventSources(
                 journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_RESUME,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                SkippingEventSource(
+                    count = 1,
+                    origin = LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_RESUME,
+                        eventFactory = { RefreshRequestEvent("lifecycle") }
+                    )
                 ),
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/EditAStoryActivity.kt
@@ -42,6 +42,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
@@ -70,10 +71,13 @@ class EditAStoryActivity : AppCompatActivity() {
         journal3Application.eventSourceDecor.apply(
             EventSources(
                 journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_RESUME,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                SkippingEventSource(
+                    count = 1,
+                    origin = LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_RESUME,
+                        eventFactory = { RefreshRequestEvent("lifecycle") }
+                    )
                 ),
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ReflectionStoriesListFragment.kt
@@ -44,6 +44,7 @@ import com.hadisatrio.libs.android.foundation.widget.recyclerview.ViewRenderer
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlin.math.roundToInt
@@ -112,10 +113,13 @@ class ReflectionStoriesListFragment : StoriesListFragment() {
         journal3Application.eventSourceDecor.apply(
             EventSources(
                 journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_START,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                SkippingEventSource(
+                    count = 1,
+                    origin = LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_START,
+                        eventFactory = { RefreshRequestEvent("lifecycle") }
+                    )
                 ),
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/UserStoriesListFragment.kt
@@ -32,6 +32,7 @@ import com.hadisatrio.libs.android.foundation.widget.recyclerview.RecyclerViewIt
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
@@ -72,10 +73,13 @@ class UserStoriesListFragment : StoriesListFragment() {
         journal3Application.eventSourceDecor.apply(
             EventSources(
                 journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_START,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                SkippingEventSource(
+                    count = 1,
+                    origin = LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_START,
+                        eventFactory = { RefreshRequestEvent("lifecycle") }
+                    )
                 ),
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryActivity.kt
@@ -52,6 +52,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.EventSources
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
 import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenters
@@ -112,10 +113,13 @@ class ViewStoryActivity : AppCompatActivity() {
         journal3Application.eventSourceDecor.apply(
             EventSources(
                 journal3Application.globalEventSource,
-                LifecycleTriggeredEventSource(
-                    lifecycleOwner = this,
-                    lifecycleEvent = Lifecycle.Event.ON_RESUME,
-                    eventFactory = { RefreshRequestEvent("lifecycle") }
+                SkippingEventSource(
+                    count = 1,
+                    origin = LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_START,
+                        eventFactory = { RefreshRequestEvent("lifecycle") }
+                    )
                 ),
                 LifecycleTriggeredEventSource(
                     lifecycleOwner = this,

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/SkippingEventSource.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/SkippingEventSource.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+import com.badoo.reaktive.observable.Observable
+import com.badoo.reaktive.observable.skip
+
+class SkippingEventSource(
+    private val count: Number,
+    private val origin: EventSource
+) : EventSource {
+
+    override fun events(): Observable<Event> {
+        return origin.events().skip(count.toLong())
+    }
+}

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/SkippingEventSourceTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/SkippingEventSourceTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+import com.badoo.reaktive.subject.publish.PublishSubject
+import com.badoo.reaktive.test.observable.test
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEvent
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSource
+import io.kotest.matchers.collections.shouldHaveSize
+import kotlin.test.Test
+
+class SkippingEventSourceTest {
+
+    @Test
+    fun `Skips N elements of the given stream`() {
+        val count = 10
+        val origin = FakeEventSource(PublishSubject())
+        val source = SkippingEventSource(count, origin)
+
+        val events = source.events().test()
+        repeat(count * 2) { origin.produce(FakeEvent()) }
+
+        events.values.shouldHaveSize(count)
+    }
+}


### PR DESCRIPTION
### What has changed

Event sources associated with `Lifecycle.Event.ON_RESUME` and `Lifecycle.Event.ON_START` now suppress their initial emission using a new decorator: `SkippingEventSource`.

### Why it was changed

`UseCase`s will always attempt to load content on first invocation, which could lead to unintended double loading when a content refresh is triggered by these sources. This behavior introduced potential race conditions, particularly after changes implemented in #221. In turn, these race conditions could cause UI inconsistencies and [potential crashes](https://mrhadisatrio.sentry.io/share/issue/5dbc43af0ae046a69461d8b97969a1ef/) during subsequent event handling.