### PR TITLE
Generalize event handling logic for use-cases

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoriesUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoriesUseCase.kt
@@ -17,15 +17,9 @@
 
 package com.hadisatrio.apps.kotlin.journal3.story
 
-import com.badoo.reaktive.observable.doOnBeforeNext
-import com.badoo.reaktive.observable.merge
-import com.badoo.reaktive.observable.subscribe
-import com.badoo.reaktive.observable.takeUntil
-import com.badoo.reaktive.subject.replay.ReplaySubject
 import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
-import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.EventHandlingUseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
-import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -35,29 +29,19 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 class ShowStoriesUseCase(
     private val stories: Stories,
     private val presenter: Presenter<Stories>,
-    private val eventSource: EventSource,
-    private val eventSink: EventSink
-) : UseCase {
+    eventSource: EventSource,
+    eventSink: EventSink
+) : EventHandlingUseCase(eventSource, eventSink) {
 
-    private val completionEvents by lazy { ReplaySubject<CompletionEvent>(bufferSize = 1) }
-
-    override fun invoke() {
+    override fun invokeInternal() {
         presentState()
-        observeEvents()
     }
 
     private fun presentState() {
         presenter.present(stories)
     }
 
-    private fun observeEvents() {
-        merge(eventSource.events(), completionEvents)
-            .takeUntil { event -> event is CompletionEvent }
-            .doOnBeforeNext { event -> eventSink.sink(event) }
-            .subscribe { event -> handleEvent(event) }
-    }
-
-    private fun handleEvent(event: Event) {
+    override fun handleEvent(event: Event) {
         when (event) {
             is SelectionEvent -> handleSelection(event)
             is RefreshRequestEvent -> presentState()
@@ -84,6 +68,6 @@ class ShowStoriesUseCase(
     }
 
     private fun handleCancellation() {
-        completionEvents.onNext(CompletionEvent())
+        complete()
     }
 }

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/EventHandlingUseCase.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/EventHandlingUseCase.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation
+
+import com.badoo.reaktive.observable.doOnBeforeNext
+import com.badoo.reaktive.observable.merge
+import com.badoo.reaktive.observable.subscribe
+import com.badoo.reaktive.observable.takeUntil
+import com.badoo.reaktive.subject.replay.ReplaySubject
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+
+abstract class EventHandlingUseCase(
+    protected val eventSource: EventSource,
+    protected val eventSink: EventSink
+) : UseCase {
+
+    private val completionEvents = ReplaySubject<CompletionEvent>(bufferSize = 1)
+
+    final override fun invoke() {
+        invokeInternal()
+        observeEvents()
+    }
+
+    abstract fun invokeInternal()
+
+    private fun observeEvents() {
+        merge(eventSource.events(), completionEvents)
+            .doOnBeforeNext { event -> eventSink.sink(event) }
+            .takeUntil { event -> (event as? CompletionEvent)?.also { onComplete() } != null }
+            .subscribe { event -> handleEvent(event) }
+    }
+
+    protected open fun onComplete() {}
+
+    abstract fun handleEvent(event: Event)
+
+    protected fun complete() {
+        completionEvents.onNext(CompletionEvent())
+    }
+}

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/EventHandlingUseCaseTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/EventHandlingUseCaseTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation
+
+import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.RecordedEventSource
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEvent
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSink
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class EventHandlingUseCaseTest {
+
+    @Test
+    fun `Handles events from event source`() {
+        val testEvent = FakeEvent()
+        val eventSource = RecordedEventSource(testEvent, CompletionEvent())
+        val eventSink = FakeEventSink()
+        val testUseCase = TestEventHandlingUseCase(eventSource, eventSink)
+
+        testUseCase.invoke()
+
+        eventSink.hasSunk { it == testEvent }
+        testUseCase.handledEvents.shouldContain(testEvent)
+    }
+
+    @Test
+    fun `Completes when completion event is emitted`() {
+        val testEvent = FakeEvent()
+        val eventSource = RecordedEventSource(testEvent, CompletionEvent())
+        val eventSink = FakeEventSink()
+        val testUseCase = TestEventHandlingUseCase(eventSource, eventSink)
+
+        testUseCase.invoke()
+
+        eventSink.hasSunk { it is CompletionEvent }
+        testUseCase.isCompleted shouldBe true
+    }
+
+    private class TestEventHandlingUseCase(
+        eventSource: EventSource,
+        eventSink: EventSink
+    ) : EventHandlingUseCase(eventSource, eventSink) {
+
+        val handledEvents = mutableListOf<Event>()
+        var isCompleted = false
+
+        override fun invokeInternal() {
+            // No-op for test
+        }
+
+        override fun handleEvent(event: Event) {
+            handledEvents.add(event)
+        }
+
+        override fun onComplete() {
+            isCompleted = true
+        }
+    }
+}


### PR DESCRIPTION
### What has changed

Introduces an abstract base class to streamline event handling logic across all use-cases.

### Why it was changed

Previously, each use-case had nearly identical event handling code. This duplication made the code harder to maintain and increased the risk of inconsistencies.