### PR TITLE
Implement size analysis and verification through Ruler

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Slow, but needed to workaround https://github.com/actions/checkout/issues/1471.
+          fetch-tags: true
 
       - name: Decode Keystore
         env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Slow, but needed to workaround https://github.com/actions/checkout/issues/1471.
+          fetch-tags: true
 
       - name: Decode Keystore
         env:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Slow, but needed to workaround https://github.com/actions/checkout/issues/1471.
+          fetch-tags: true
 
       - name: Decode Keystore
         env:

--- a/app-android-journal3/build.gradle.kts
+++ b/app-android-journal3/build.gradle.kts
@@ -96,6 +96,13 @@ ruler {
     }
 }
 
+tasks.named("check").configure {
+    val isOnCi = providers.environmentVariable("CI").isPresent
+    
+    dependsOn("analyzeDebugBundle")
+    if (isOnCi) dependsOn("analyzeReleaseBundle")
+}
+
 sentry {
     org.set("mrhadisatrio")
     projectName.set("journal3")

--- a/app-android-journal3/build.gradle.kts
+++ b/app-android-journal3/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
     alias(libs.plugins.sentry)
+    alias(libs.plugins.ruler)
     alias(libs.plugins.appVersioning)
 }
 
@@ -81,6 +82,13 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.kotest.assertions)
     testImplementation(libs.robolectric)
+}
+
+ruler {
+    abi.set("arm64-v8a")
+    locale.set("en")
+    screenDensity.set(422)
+    sdkVersion.set(34)
 }
 
 sentry {

--- a/app-android-journal3/build.gradle.kts
+++ b/app-android-journal3/build.gradle.kts
@@ -89,6 +89,11 @@ ruler {
     locale.set("en")
     screenDensity.set(422)
     sdkVersion.set(34)
+
+    verification {
+        downloadSizeThreshold = 15_000_000
+        installSizeThreshold = 35_000_000
+    }
 }
 
 sentry {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ plugins {
     alias(libs.plugins.kotlinMultiplatform).apply(false)
     alias(libs.plugins.kover).apply(false)
     alias(libs.plugins.detekt).apply(false)
+    alias(libs.plugins.ruler).apply(false)
     alias(libs.plugins.sonar)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kover = { id = "org.jetbrains.kotlinx.kover", version = "0.7.5" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version = "1.23.6" }
+ruler = { id = "com.hadisatrio.libs.android.ruler", version = "1.0.0-alpha.2" }
 sentry = { id = "io.sentry.android.gradle", version = "4.10.0" }
 sonar = { id = "org.sonarqube", version = "4.0.0.2929" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,13 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.hadisatrio.libs.android.ruler") {
+                useModule("com.hadisatrio.libs.android:ruler-gradle-plugin:1.0.0-alpha.2")
+            }
+        }
+    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
### What has changed

We now analyze and verify that the Android AAB would be under 15MB and 35MB for download and install size respectively. This is done by leveraging [Ruler](https://github.com/MrHadiSatrio/Ruler).

### Why it was changed

So that we can get a hold of how our AAB size grow/shrink over time.