### PR TITLE
Provide latitude and longitude as a value pair

### DIFF
--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
@@ -47,6 +47,9 @@ class LocationManagerCoordinates(
     override val longitude: Double
         @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
         get() = location().longitude
+    override val latlng: Pair<Double, Double>
+        @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
+        get() = location().let { it.latitude to it.longitude }
 
     private val provider: String? get() {
         val criteria = Criteria().apply { accuracy = Criteria.ACCURACY_FINE }

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
@@ -41,12 +41,6 @@ class LocationManagerCoordinates(
         clock
     )
 
-    override val latitude: Double
-        @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
-        get() = location().latitude
-    override val longitude: Double
-        @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
-        get() = location().longitude
     override val latlng: Pair<Double, Double>
         @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
         get() = location().let { it.latitude to it.longitude }

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
@@ -45,6 +45,13 @@ class PermissionAwareCoordinates(
             throw SecurityException("Required permission(s) is not granted.")
         }
     }
+    override val latlng: Pair<Double, Double> get() {
+        return if (checkPermission()) {
+            origin.latlng
+        } else {
+            throw SecurityException("Required permission(s) is not granted.")
+        }
+    }
 
     private fun checkPermission(): Boolean {
         val activity = currentActivity.acquire()

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
@@ -31,20 +31,6 @@ class PermissionAwareCoordinates(
     private val origin: Coordinates
 ) : Coordinates() {
 
-    override val latitude: Double get() {
-        return if (checkPermission()) {
-            origin.latitude
-        } else {
-            throw SecurityException("Required permission(s) is not granted.")
-        }
-    }
-    override val longitude: Double get() {
-        return if (checkPermission()) {
-            origin.longitude
-        } else {
-            throw SecurityException("Required permission(s) is not granted.")
-        }
-    }
     override val latlng: Pair<Double, Double> get() {
         return if (checkPermission()) {
             origin.latlng

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinatesTest.kt
@@ -57,29 +57,24 @@ class LocationManagerCoordinatesTest {
 
     @Test(timeout = 10_000)
     fun `Returns device location`() {
-        var lat = 0.0
-        var lng = 0.0
+        var latlng = 0.0 to 0.0
         val thread = Thread {
-            lat = coordinates.latitude
-            lng = coordinates.longitude
+            latlng = coordinates.latlng
         }
 
         thread.start()
         shadowLocationManager.enqueueSimulateLocation(gpsLocation)
         thread.join()
 
-        lat.shouldBe(gpsLocation.latitude)
-        lng.shouldBe(gpsLocation.longitude)
+        latlng.shouldBe(gpsLocation.latitude to gpsLocation.longitude)
     }
 
     @Test(timeout = 10_000)
     fun `Prevents spamming the LocationManager on rapid requests`() {
         val thread = Thread {
-            repeat(10) { coordinates.latitude }
-            repeat(10) { coordinates.longitude }
+            repeat(10) { coordinates.latlng }
             clock.advanceBy(11.seconds)
-            repeat(10) { coordinates.latitude }
-            repeat(10) { coordinates.longitude }
+            repeat(10) { coordinates.latlng }
         }
 
         thread.start()
@@ -96,8 +91,7 @@ class LocationManagerCoordinatesTest {
         repeat(2) {
             threads.add(
                 Thread {
-                    coordinates.latitude
-                    coordinates.longitude
+                    coordinates.latlng
                 }
             )
         }
@@ -114,8 +108,7 @@ class LocationManagerCoordinatesTest {
         shadowLocationManager.setProviderEnabled(LocationManager.GPS_PROVIDER, false)
         shadowLocationManager.setProviderEnabled(LocationManager.PASSIVE_PROVIDER, false)
         val thread = Thread {
-            shouldThrow<IllegalStateException> { coordinates.latitude }
-            shouldThrow<IllegalStateException> { coordinates.longitude }
+            shouldThrow<IllegalStateException> { coordinates.latlng }
         }
 
         thread.start()

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinatesTest.kt
@@ -49,7 +49,6 @@ class PermissionAwareCoordinatesTest {
     fun `Forwards the call to origin when permissions are already granted`() {
         shadowActivity.grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
 
-        coordinates.latitude.shouldBe(origin.latitude)
-        coordinates.longitude.shouldBe(origin.longitude)
+        coordinates.latlng.shouldBe(origin.latlng)
     }
 }

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
@@ -19,15 +19,20 @@ package com.hadisatrio.libs.kotlin.geography
 
 abstract class Coordinates {
 
+    @Deprecated("Inefficient; Use latlng instead.", replaceWith = ReplaceWith("latlng"))
     abstract val latitude: Double
+
+    @Deprecated("Inefficient; Use latlng instead.", replaceWith = ReplaceWith("latlng"))
     abstract val longitude: Double
+
+    abstract val latlng: Pair<Double, Double>
 
     fun distanceTo(other: Coordinates): Distance {
         return Distance(this, other)
     }
 
     final override fun toString(): String {
-        return "$latitude,$longitude"
+        return latlng.let { (lat, lng) -> "$lat,$lng" }
     }
 
     final override fun equals(other: Any?): Boolean {

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
@@ -19,12 +19,6 @@ package com.hadisatrio.libs.kotlin.geography
 
 abstract class Coordinates {
 
-    @Deprecated("Inefficient; Use latlng instead.", replaceWith = ReplaceWith("latlng"))
-    abstract val latitude: Double
-
-    @Deprecated("Inefficient; Use latlng instead.", replaceWith = ReplaceWith("latlng"))
-    abstract val longitude: Double
-
     abstract val latlng: Pair<Double, Double>
 
     fun distanceTo(other: Coordinates): Distance {

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Distance.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Distance.kt
@@ -30,10 +30,12 @@ class Distance(
 ) : Comparable<Distance> {
 
     val value: Double by lazy {
-        val dLat = (other.latitude - one.latitude).toRadians()
-        val dLon = (other.longitude - one.longitude).toRadians()
-        val originLat = (one.latitude).toRadians()
-        val destinationLat = (other.latitude).toRadians()
+        val oneLatLng = one.latlng
+        val otherLatLng = other.latlng
+        val dLat = (otherLatLng.first - oneLatLng.first).toRadians()
+        val dLon = (otherLatLng.second - oneLatLng.second).toRadians()
+        val originLat = (oneLatLng.first).toRadians()
+        val destinationLat = (otherLatLng.first).toRadians()
 
         val a = sin(dLat / 2).pow(2.toDouble()) +
             sin(dLon / 2).pow(2.toDouble()) *

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
@@ -22,6 +22,8 @@ class LiteralCoordinates(
     override val longitude: Double
 ) : Coordinates() {
 
+    override val latlng: Pair<Double, Double> get() = latitude to longitude
+
     constructor(string: String) : this(
         string.split(',', limit = 2).first().trim().toDouble(),
         string.split(',', limit = 2).last().trim().toDouble()

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
@@ -18,8 +18,8 @@
 package com.hadisatrio.libs.kotlin.geography
 
 class LiteralCoordinates(
-    override val latitude: Double,
-    override val longitude: Double
+    private val latitude: Double,
+    private val longitude: Double
 ) : Coordinates() {
 
     override val latlng: Pair<Double, Double> get() = latitude to longitude


### PR DESCRIPTION
### What has changed

`Coordinates` now provides `latitude` and `longitude` as a unified pair.

### Why it was changed

To simplify things now that we're doing something more substantial with location data (i.e., #313).