### PR TITLE
Fix completion events handling in SelectAPlaceUseCase

### DIFF
--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -17,10 +17,8 @@
 
 package com.hadisatrio.apps.kotlin.journal3.geography
 
-import com.badoo.reaktive.subject.replay.ReplaySubject
 import com.hadisatrio.libs.kotlin.foundation.EventHandlingUseCase
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
-import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
@@ -42,8 +40,6 @@ class SelectAPlaceUseCase(
     eventSource: EventSource,
     eventSink: EventSink,
 ) : EventHandlingUseCase(eventSource, eventSink) {
-
-    private val completionEvents by lazy { ReplaySubject<CompletionEvent>(bufferSize = 1) }
 
     private var presentedPlaces: Iterable<Place> = emptyList()
 
@@ -81,7 +77,7 @@ class SelectAPlaceUseCase(
                 val position = identifier.toInt()
                 val target = presentedPlaces.elementAt(position)
                 eventSink.sink(SelectionEvent("place", target.id.toString()))
-                completionEvents.onNext(CompletionEvent())
+                complete()
             }
         }
     }
@@ -102,10 +98,10 @@ class SelectAPlaceUseCase(
 
     private fun handleModalDismissal(event: ModalDismissalEvent) {
         if (event.modalKind != "presentation_retrial_confirmation") return
-        completionEvents.onNext(CompletionEvent())
+        complete()
     }
 
     private fun handleCancellation() {
-        completionEvents.onNext(CompletionEvent())
+        complete()
     }
 }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCaseTest.kt
@@ -35,6 +35,7 @@ import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.SelfPopulatingPlaces
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlaces
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.doubles.exactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
@@ -186,8 +187,10 @@ class SelectAPlaceUseCaseTest {
     }
 
     @Test(timeout = 5_000)
-    fun `Stops upon receiving cancellation events`() {
+    fun `Completes upon receiving cancellation events`() {
         listOf(CancellationEvent("user"), CancellationEvent("system")).forEach { event ->
+            val eventSink = mockk<EventSink>(relaxed = true)
+
             SelectAPlaceUseCase(
                 places = places,
                 presenter = presenter,
@@ -195,6 +198,10 @@ class SelectAPlaceUseCaseTest {
                 eventSource = RecordedEventSource(event),
                 eventSink = eventSink
             )()
+
+            verify(exactly = 1) {
+                eventSink.sink(withArg { it.shouldBeInstanceOf<CompletionEvent>() })
+            }
         }
     }
 


### PR DESCRIPTION
### What has changed

`SelectAPlaceUseCase` now correctly routes `CompletionEvent`s through its super class rather than to its internal stream.

### Why it was changed

This was an oversight from #273.