### PR TITLE
Source coordinates from Google whenever available

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -54,7 +54,7 @@ import com.hadisatrio.libs.android.foundation.event.ExecutorDispatchingEventSink
 import com.hadisatrio.libs.android.foundation.modal.AlertDialogModalPresenter
 import com.hadisatrio.libs.android.foundation.os.SystemLog
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
-import com.hadisatrio.libs.android.geography.LocationManagerCoordinates
+import com.hadisatrio.libs.android.geography.AndroidCoordinates
 import com.hadisatrio.libs.android.geography.PermissionAwareCoordinates
 import com.hadisatrio.libs.android.io.content.ContentResolverSources
 import com.hadisatrio.libs.kotlin.foundation.Decor
@@ -278,8 +278,8 @@ class RealJournal3Application : Journal3Application() {
         Clock.System
     }
 
-    private val locationManagerCoordinates: LocationManagerCoordinates by lazy {
-        LocationManagerCoordinates(this, clock)
+    private val locationManagerCoordinates: AndroidCoordinates by lazy {
+        AndroidCoordinates(this, clock)
     }
 
     private val coordinates: Coordinates by lazy {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ androidx-startup = { module = "androidx.startup:startup-runtime", version = "1.2
 androidx-workmanager = { module = "androidx.work:work-runtime-ktx", version = "2.9.0" }
 androidx-test-runner = { module = "androidx.test:runner", version = "1.6.2" }
 
+gms-location = { module = "com.google.android.gms:play-services-location", version = "21.3.0" }
+
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.1" }
 kotlinx-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version = "1.7.3" }
 

--- a/lib-kmm-geography/build.gradle.kts
+++ b/lib-kmm-geography/build.gradle.kts
@@ -32,6 +32,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 implementation(libs.assent)
+                implementation(libs.gms.location)
             }
         }
         val androidUnitTest by getting {

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinates.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.geography
+
+import android.app.Application
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.Companion.PRIVATE
+import com.google.android.gms.common.GoogleApiAvailabilityLight
+import com.google.android.gms.common.api.CommonStatusCodes.SUCCESS
+import com.hadisatrio.libs.kotlin.geography.Coordinates
+import com.hadisatrio.libs.kotlin.geography.Speed
+import kotlinx.datetime.Clock
+
+class AndroidCoordinates(
+    private val application: Application,
+    private val clock: Clock
+) : Coordinates(), Speed {
+
+    override val latlng: Pair<Double, Double> get() = delegate.latlng
+    override val value: Double get() = (delegate as Speed).value
+
+    @VisibleForTesting(otherwise = PRIVATE)
+    internal val delegate: Coordinates by lazy {
+        val checker = GoogleApiAvailabilityLight.getInstance()
+        val gmsAvailable = checker.isGooglePlayServicesAvailable(application) == SUCCESS
+        if (gmsAvailable) {
+            GmsCoordinates(application, clock)
+        } else {
+            LocationManagerCoordinates(application, clock)
+        }
+    }
+}

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinates.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.geography
+
+import android.Manifest.permission.ACCESS_COARSE_LOCATION
+import android.Manifest.permission.ACCESS_FINE_LOCATION
+import android.content.Context
+import android.location.Location
+import androidx.annotation.RequiresPermission
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.Priority
+import com.google.android.gms.tasks.Tasks
+import com.hadisatrio.libs.kotlin.geography.Coordinates
+import com.hadisatrio.libs.kotlin.geography.Speed
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.minutes
+
+class GmsCoordinates(
+    private val client: FusedLocationProviderClient,
+    private val clock: Clock
+) : Coordinates(), Speed {
+
+    constructor(context: Context, clock: Clock) : this(
+        LocationServices.getFusedLocationProviderClient(context),
+        clock
+    )
+
+    override val latlng: Pair<Double, Double>
+        @RequiresPermission(allOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
+        get() {
+            return location().let { it.latitude to it.longitude }
+        }
+    override val value: Double
+        @RequiresPermission(allOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
+        get() {
+            return location().speed.toDouble()
+        }
+
+    private var lastDeviceLocation: Location? = null
+    private var lastFetchInstant: Instant? = null
+
+    @Synchronized
+    @RequiresPermission(allOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
+    private fun location(): Location {
+        val lastFetchInstant = this.lastFetchInstant
+        val currentInstant = clock.now()
+        val updateRequired =
+            lastFetchInstant == null || currentInstant - lastFetchInstant > 10.minutes
+
+        if (updateRequired) {
+            val task = client.getCurrentLocation(Priority.PRIORITY_HIGH_ACCURACY, null)
+            this.lastDeviceLocation = Tasks.await(task)
+            this.lastFetchInstant = clock.now()
+        }
+
+        return this.lastDeviceLocation!!
+    }
+}

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinatesTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.geography
+
+import android.os.Build
+import androidx.test.runner.AndroidJUnit4
+import com.google.android.gms.common.GoogleApiAvailabilityLight
+import com.google.android.gms.common.api.CommonStatusCodes.ERROR
+import com.google.android.gms.common.api.CommonStatusCodes.SUCCESS
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class AndroidCoordinatesTest {
+
+    private val checker = mockk<GoogleApiAvailabilityLight>()
+    private val coordinates = AndroidCoordinates(RuntimeEnvironment.getApplication(), TestClock())
+
+    @BeforeTest
+    fun `Init mocks`() {
+        mockkStatic(GoogleApiAvailabilityLight::class)
+        every { GoogleApiAvailabilityLight.getInstance() } returns checker
+    }
+
+    @Test
+    fun `Delegates to GmsCoordinates whenever Google Play Services is available`() {
+        every { checker.isGooglePlayServicesAvailable(any()) } returns SUCCESS
+
+        coordinates.delegate.shouldBeInstanceOf<GmsCoordinates>()
+    }
+
+    @Test
+    fun `Resorts to LocationManagerCoordinates in case Google Play Services is not available`() {
+        every { checker.isGooglePlayServicesAvailable(any()) } returns ERROR
+
+        coordinates.delegate.shouldBeInstanceOf<LocationManagerCoordinates>()
+    }
+}

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinatesTest.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.android.geography
+
+import android.location.Location
+import android.location.LocationManager
+import android.os.Build
+import androidx.test.runner.AndroidJUnit4
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.google.android.gms.tasks.Tasks
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [Build.VERSION_CODES.Q])
+class GmsCoordinatesTest {
+
+    private val gpsLocation = Location(LocationManager.GPS_PROVIDER)
+    private val client = mockk<FusedLocationProviderClient>()
+    private val clock = TestClock()
+    private val coordinates = GmsCoordinates(client, clock)
+
+    @BeforeTest
+    fun `Init mocks`() {
+        gpsLocation.latitude = -6.2244727
+        gpsLocation.longitude = 106.8101278
+        gpsLocation.speed = 3F
+        every { client.getCurrentLocation(any<Int>(), anyNullable()) } returns Tasks.forResult(
+            gpsLocation
+        )
+    }
+
+    @Test
+    fun `Returns device location`() {
+        var latlng = 0.0 to 0.0
+        val thread = Thread {
+            latlng = coordinates.latlng
+        }
+
+        thread.start()
+        thread.join()
+
+        latlng.shouldBe(gpsLocation.latitude to gpsLocation.longitude)
+    }
+
+    @Test
+    fun `Returns device speed`() {
+        var speed = 0.0
+        val thread = Thread {
+            speed = coordinates.value
+        }
+
+        thread.start()
+        thread.join()
+
+        speed.shouldBe(gpsLocation.speed)
+    }
+
+    @Test
+    fun `Prevents spamming the client on rapid requests`() {
+        val thread = Thread {
+            repeat(10) { coordinates.latlng }
+            repeat(10) { coordinates.value }
+            clock.advanceBy(11.minutes)
+            repeat(10) { coordinates.latlng }
+            repeat(10) { coordinates.value }
+        }
+
+        thread.start()
+        thread.join()
+
+        verify(exactly = 2) { client.getCurrentLocation(any<Int>(), anyNullable()) }
+    }
+
+    @Test
+    fun `Prevents spamming the LocationManager on multi-threaded requests`() {
+        val threads = mutableSetOf<Thread>()
+        repeat(2) {
+            val thread = Thread { coordinates.latlng }
+            threads.add(thread)
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        verify(exactly = 1) { client.getCurrentLocation(any<Int>(), anyNullable()) }
+    }
+}


### PR DESCRIPTION
### What has changed

We introduced `GmsCoordinates` which, true to its name, sources latitude, longitude, and speed information from Google Mobile Services (GMS). To satisfy the scenario wherein GMS is not available, we also introduced `AndroidCoordinates` to act as a proxy.

### Why it was changed

GMS-driven location fetching is generally the recommended approach. According to the Android developer documentation, it is also more likely to minimize background restrictions, which is important for our use case.