### PR TITLE
Fix missing secret linking on Actions

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -37,6 +37,8 @@ jobs:
           RELEASE_KEY_STORE_PASSWORD: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_KEY_GOOGLE_API: ${{ secrets.RELEASE_KEY_GOOGLE_API }}
+          DEBUG_KEY_GOOGLE_API: ${{ secrets.DEBUG_KEY_GOOGLE_API }}
           RELEASE_KEY_HERE_API: ${{ secrets.RELEASE_KEY_HERE_API }}
           DEBUG_KEY_HERE_API: ${{ secrets.DEBUG_KEY_HERE_API }}
           RELEASE_KEY_OAI_API: ${{ secrets.RELEASE_KEY_OAI_API }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
           RELEASE_KEY_STORE_PASSWORD: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_KEY_GOOGLE_API: ${{ secrets.RELEASE_KEY_GOOGLE_API }}
+          DEBUG_KEY_GOOGLE_API: ${{ secrets.DEBUG_KEY_GOOGLE_API }}
           RELEASE_KEY_HERE_API: ${{ secrets.RELEASE_KEY_HERE_API }}
           DEBUG_KEY_HERE_API: ${{ secrets.DEBUG_KEY_HERE_API }}
           RELEASE_KEY_OAI_API: ${{ secrets.RELEASE_KEY_OAI_API }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -38,6 +38,8 @@ jobs:
           RELEASE_KEY_STORE_PASSWORD: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_PASSWORD: ${{ secrets.RELEASE_KEY_PASSWORD }}
+          RELEASE_KEY_GOOGLE_API: ${{ secrets.RELEASE_KEY_GOOGLE_API }}
+          DEBUG_KEY_GOOGLE_API: ${{ secrets.DEBUG_KEY_GOOGLE_API }}
           RELEASE_KEY_HERE_API: ${{ secrets.RELEASE_KEY_HERE_API }}
           DEBUG_KEY_HERE_API: ${{ secrets.DEBUG_KEY_HERE_API }}
           RELEASE_KEY_OAI_API: ${{ secrets.RELEASE_KEY_OAI_API }}


### PR DESCRIPTION
### What has changed

Add missing linking for Google secrets added as part of #321 to the Actions file.

### Why it was changed

As they were not added to the ENV, these secrets effectively got shipped as an empty string, which caused Places API queries to fail.