### PR TITLE
Improve the accuracy of auto-captured place visits

### DIFF
--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -33,6 +33,7 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+import com.hadisatrio.libs.kotlin.geography.Coordinates
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.Speed
 import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
@@ -41,6 +42,7 @@ import java.util.concurrent.Executor
 import kotlin.time.Duration
 
 abstract class Journal3Application : Application() {
+    abstract val coordinates: Coordinates
     abstract val speed: Speed
     abstract val places: Places
     abstract val story: Story

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -282,7 +282,7 @@ class RealJournal3Application : Journal3Application() {
         AndroidCoordinates(this, clock)
     }
 
-    private val coordinates: Coordinates by lazy {
+    override val coordinates: Coordinates by lazy {
         PermissionAwareCoordinates(
             application = this,
             origin = locationManagerCoordinates

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentCapturingWork.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/MomentCapturingWork.kt
@@ -41,6 +41,7 @@ class MomentCapturingWork(
             story = journal3Application.story,
             places = journal3Application.places,
             speed = journal3Application.speed,
+            coordinates = journal3Application.coordinates,
             clock = journal3Application.clock
         )()
         return Result.success()

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -37,6 +37,8 @@ import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEventSink
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.foundation.presentation.fake.FakePresenter
+import com.hadisatrio.libs.kotlin.geography.Coordinates
+import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.SelfPopulatingPlaces
 import com.hadisatrio.libs.kotlin.geography.Speed
@@ -52,6 +54,7 @@ import kotlin.time.Duration.Companion.hours
 
 class FakeJournal3Application : Journal3Application() {
 
+    override val coordinates: Coordinates by lazy { LiteralCoordinates("-6.275489,107.050648") }
     override val speed: Speed by lazy { StaticSpeed(5.0) }
     override val places: Places by lazy { SelfPopulatingPlaces(10, FakePlaces()) }
     override val story: Story by lazy { SelfPopulatingStory(10, FakeStory()) }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
@@ -49,7 +49,7 @@ class CaptureAMomentUseCase(
         val todaysMoments = TimeRangedMoments(last24h, cachedStory.moments)
 
         var place = places.first()
-        val vicinityMoments = VicinityMoments(place.coordinates, DISTANCE_LIMIT_METER, cachedStory.moments)
+        val vicinityMoments = VicinityMoments(place.coordinates, coordinates.accuracyInMeters, cachedStory.moments)
         place = vicinityMoments.firstOrNull()?.place ?: place
 
         val beenHereRecently = todaysMoments.any { it.place.id == place.id }
@@ -64,7 +64,6 @@ class CaptureAMomentUseCase(
 
     companion object {
         private const val SPEED_LIMIT_METER_PER_SECOND = 5
-        private const val DISTANCE_LIMIT_METER = 25.0
         private const val ACCURACY_LIMIT_METER = 50
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
@@ -23,6 +23,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.EditableMomentInStory
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStory
 import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.geography.Coordinates
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.geography.Speed
 import kotlinx.datetime.Clock
@@ -31,12 +32,15 @@ import kotlin.time.Duration.Companion.hours
 class CaptureAMomentUseCase(
     private val story: Story,
     private val places: Places,
+    private val coordinates: Coordinates,
     private val speed: Speed,
     private val clock: Clock
 ) : UseCase {
 
     override fun invoke() {
-        if (speed.value > SPEED_LIMIT_METER_PER_SECOND) return
+        val userIsMoving = speed.value > SPEED_LIMIT_METER_PER_SECOND
+        val coordinatesIsInaccurate = coordinates.accuracyInMeters > ACCURACY_LIMIT_METER
+        if (userIsMoving || coordinatesIsInaccurate) return
 
         val cachedStory = CachingStory(story)
 
@@ -61,5 +65,6 @@ class CaptureAMomentUseCase(
     companion object {
         private const val SPEED_LIMIT_METER_PER_SECOND = 5
         private const val DISTANCE_LIMIT_METER = 25.0
+        private const val ACCURACY_LIMIT_METER = 50
     }
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
@@ -45,11 +45,11 @@ class CaptureAMomentUseCase(
         val todaysMoments = TimeRangedMoments(last24h, cachedStory.moments)
 
         var place = places.first()
-        val beenHereRecently = todaysMoments.any { it.place.id == place.id }
-        if (beenHereRecently) return
-
         val vicinityMoments = VicinityMoments(place.coordinates, DISTANCE_LIMIT_METER, cachedStory.moments)
         place = vicinityMoments.firstOrNull()?.place ?: place
+
+        val beenHereRecently = todaysMoments.any { it.place.id == place.id }
+        if (beenHereRecently) return
 
         val moment = EditableMomentInStory(INVALID_UUID, story)
         moment.update(currentTimestamp)

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
@@ -27,6 +27,12 @@ class VicinityMoments(
     private val origin: Moments
 ) : Moments {
 
+    constructor(
+        coordinates: Coordinates,
+        distanceLimitInM: Number,
+        origin: Moments
+    ) : this(coordinates, distanceLimitInM.toDouble(), origin)
+
     override fun count(): Int {
         return toList().size
     }

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCaseTest.kt
@@ -20,7 +20,6 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
 import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
 import com.hadisatrio.libs.kotlin.geography.Place
-import com.hadisatrio.libs.kotlin.geography.SelfPopulatingPlaces
 import com.hadisatrio.libs.kotlin.geography.Speed
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlace
 import com.hadisatrio.libs.kotlin.geography.fake.FakePlaces
@@ -32,16 +31,28 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
 
 class CaptureAMomentUseCaseTest {
 
     private val story = FakeStory()
-    private val places = SelfPopulatingPlaces(1, FakePlaces())
+    private val gambirStation = FakePlace(coordinates = LiteralCoordinates("-6.1765638,106.8299464"))
+    private val gambirBusDepot = FakePlace(coordinates = LiteralCoordinates("-6.1766638,106.8300464"))
+    private val places = FakePlaces(gambirStation, gambirBusDepot)
     private val speed = mockk<Speed>()
+    private val arbitraryInstant = Instant.fromEpochMilliseconds(1735316550)
     private val clock = mockk<Clock>()
 
     private val useCase = CaptureAMomentUseCase(story, places, speed, clock)
+
+    @BeforeTest
+    fun `Init mocks`() {
+        every { speed.value } returns 0.0
+        every { clock.now() } returns arbitraryInstant
+    }
 
     @Test
     fun `Captures a non-notable moment about the currently visited place`() {
@@ -52,28 +63,25 @@ class CaptureAMomentUseCaseTest {
 
         story.moments.shouldHaveSize(1)
         val captured = story.moments.first()
-        captured.timestamp.value.shouldBeEqual(Instant.DISTANT_FUTURE)
+        captured.timestamp.value.shouldBeEqual(arbitraryInstant)
         captured.isNotable.shouldBeFalse()
         captured.place.id.shouldBeEqual(places.first().id)
     }
 
     @Test
     fun `Prioritizes a known nearby place whilst capturing`() {
-        every { speed.value } returns 0.0
-        every { clock.now() } returns Instant.DISTANT_FUTURE
-        val onePlace = FakePlace(coordinates = LiteralCoordinates("-6.275489,107.050648"))
-        val another10mAway = FakePlace(coordinates = LiteralCoordinates("-6.275500,107.050740"))
-        val placesList = mutableListOf<Place>(onePlace, another10mAway)
+        val placesList = mutableListOf<Place>(gambirStation, gambirBusDepot)
         val places = FakePlaces(placesList)
         val useCase = CaptureAMomentUseCase(story, places, speed, clock)
 
-        useCase()
-        placesList.removeFirst() // …so that the next execution would pick up the 2nd place.
-        useCase()
+        useCase() // …captures visit to Gambir Station.
+        placesList.removeFirst() // …so that the next execution would pick up the bus depot.
+        every { clock.now() } returns arbitraryInstant + 1.days + 1.seconds
+        useCase() // …attempts to capture the bus depot.
 
         story.moments.shouldHaveSize(2)
         story.moments.distinctBy { it.place.id }.shouldHaveSize(1)
-        story.moments.map { it.place.id }.first().shouldBeEqual(onePlace.id)
+        story.moments.map { it.place.id }.first().shouldBeEqual(gambirStation.id)
     }
 
     @Test
@@ -86,6 +94,22 @@ class CaptureAMomentUseCaseTest {
         repeat(10) { useCase() }
 
         story.moments.shouldHaveSize(1)
+    }
+
+    @Test
+    fun `Skips capturing if the place, post correction, is already written for today`() {
+        val placesList = mutableListOf<Place>(gambirStation, gambirBusDepot)
+        val places = FakePlaces(placesList)
+        val useCase = CaptureAMomentUseCase(story, places, speed, clock)
+
+        useCase() // …captures visit to Gambir Station.
+        placesList.removeFirst() // …so that the next execution would pick up the bus depot.
+        // Unlike the previous test case, we don't advance the time.
+        useCase() // …attempts to capture the bus depot.
+
+        story.moments.shouldHaveSize(1)
+        story.moments.distinctBy { it.place.id }.shouldHaveSize(1)
+        story.moments.map { it.place.id }.first().shouldBeEqual(gambirStation.id)
     }
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCaseTest.kt
@@ -18,6 +18,7 @@
 package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
+import com.hadisatrio.libs.kotlin.geography.Coordinates
 import com.hadisatrio.libs.kotlin.geography.LiteralCoordinates
 import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.Speed
@@ -42,23 +43,22 @@ class CaptureAMomentUseCaseTest {
     private val gambirStation = FakePlace(coordinates = LiteralCoordinates("-6.1765638,106.8299464"))
     private val gambirBusDepot = FakePlace(coordinates = LiteralCoordinates("-6.1766638,106.8300464"))
     private val places = FakePlaces(gambirStation, gambirBusDepot)
+    private val coordinates = mockk<Coordinates>()
     private val speed = mockk<Speed>()
     private val arbitraryInstant = Instant.fromEpochMilliseconds(1735316550)
     private val clock = mockk<Clock>()
 
-    private val useCase = CaptureAMomentUseCase(story, places, speed, clock)
+    private val useCase = CaptureAMomentUseCase(story, places, coordinates, speed, clock)
 
     @BeforeTest
     fun `Init mocks`() {
         every { speed.value } returns 0.0
+        every { coordinates.accuracyInMeters } returns 50F
         every { clock.now() } returns arbitraryInstant
     }
 
     @Test
     fun `Captures a non-notable moment about the currently visited place`() {
-        every { speed.value } returns 0.0
-        every { clock.now() } returns Instant.DISTANT_FUTURE
-
         useCase()
 
         story.moments.shouldHaveSize(1)
@@ -72,7 +72,7 @@ class CaptureAMomentUseCaseTest {
     fun `Prioritizes a known nearby place whilst capturing`() {
         val placesList = mutableListOf<Place>(gambirStation, gambirBusDepot)
         val places = FakePlaces(placesList)
-        val useCase = CaptureAMomentUseCase(story, places, speed, clock)
+        val useCase = CaptureAMomentUseCase(story, places, coordinates, speed, clock)
 
         useCase() // …captures visit to Gambir Station.
         placesList.removeFirst() // …so that the next execution would pick up the bus depot.
@@ -86,9 +86,6 @@ class CaptureAMomentUseCaseTest {
 
     @Test
     fun `Skips capturing if there is an existing moment about the place written today`() {
-        every { speed.value } returns 0.0
-        every { clock.now() } returns Instant.DISTANT_FUTURE
-
         // Places stay intact, so multiple execution would point to the same place to
         // be captured. Hence sufficient to simulate the scenario we want.
         repeat(10) { useCase() }
@@ -100,7 +97,7 @@ class CaptureAMomentUseCaseTest {
     fun `Skips capturing if the place, post correction, is already written for today`() {
         val placesList = mutableListOf<Place>(gambirStation, gambirBusDepot)
         val places = FakePlaces(placesList)
-        val useCase = CaptureAMomentUseCase(story, places, speed, clock)
+        val useCase = CaptureAMomentUseCase(story, places, coordinates, speed, clock)
 
         useCase() // …captures visit to Gambir Station.
         placesList.removeFirst() // …so that the next execution would pick up the bus depot.
@@ -113,9 +110,17 @@ class CaptureAMomentUseCaseTest {
     }
 
     @Test
+    fun `Skips capturing when coordinates accuracy is greater than 50 meters`() {
+        every { coordinates.accuracyInMeters } returns 51F
+
+        useCase()
+
+        story.moments.shouldBeEmpty()
+    }
+
+    @Test
     fun `Skips capture if the user is moving`() {
         every { speed.value } returns 100.0
-        every { clock.now() } returns Instant.DISTANT_FUTURE
 
         useCase()
 

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/AndroidCoordinates.kt
@@ -32,6 +32,7 @@ class AndroidCoordinates(
 ) : Coordinates(), Speed {
 
     override val latlng: Pair<Double, Double> get() = delegate.latlng
+    override val accuracyInMeters: Float get() = delegate.accuracyInMeters
     override val value: Double get() = (delegate as Speed).value
 
     @VisibleForTesting(otherwise = PRIVATE)

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinates.kt
@@ -47,6 +47,11 @@ class GmsCoordinates(
         get() {
             return location().let { it.latitude to it.longitude }
         }
+    override val accuracyInMeters: Float
+        @RequiresPermission(allOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
+        get() {
+            return location().accuracy
+        }
     override val value: Double
         @RequiresPermission(allOf = [ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION])
         get() {

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinates.kt
@@ -46,6 +46,10 @@ class LocationManagerCoordinates(
         @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
         get() = location().let { it.latitude to it.longitude }
 
+    override val accuracyInMeters: Float
+        @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
+        get() = location().accuracy
+
     override val value: Double
         @RequiresPermission(allOf = [ ACCESS_COARSE_LOCATION, ACCESS_FINE_LOCATION ])
         get() = location().speed.toDouble()

--- a/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
+++ b/lib-kmm-geography/src/androidMain/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinates.kt
@@ -40,6 +40,13 @@ class PermissionAwareCoordinates(
             throw SecurityException("Required permission(s) is not granted.")
         }
     }
+    override val accuracyInMeters: Float get() {
+        return if (checkPermission()) {
+            origin.accuracyInMeters
+        } else {
+            throw SecurityException("Required permission(s) is not granted.")
+        }
+    }
 
     constructor(application: Application, origin: Coordinates) : this(
         application,

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/GmsCoordinatesTest.kt
@@ -47,22 +47,26 @@ class GmsCoordinatesTest {
         gpsLocation.latitude = -6.2244727
         gpsLocation.longitude = 106.8101278
         gpsLocation.speed = 3F
+        gpsLocation.accuracy = 10F
         every { client.getCurrentLocation(any<Int>(), anyNullable()) } returns Tasks.forResult(
             gpsLocation
         )
     }
 
     @Test
-    fun `Returns device location`() {
+    fun `Returns device location and its accuracy`() {
         var latlng = 0.0 to 0.0
+        var accuracy = 0F
         val thread = Thread {
             latlng = coordinates.latlng
+            accuracy = coordinates.accuracyInMeters
         }
 
         thread.start()
         thread.join()
 
         latlng.shouldBe(gpsLocation.latitude to gpsLocation.longitude)
+        accuracy.shouldBe(gpsLocation.accuracy)
     }
 
     @Test

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/LocationManagerCoordinatesTest.kt
@@ -56,10 +56,12 @@ class LocationManagerCoordinatesTest {
     }
 
     @Test(timeout = 10_000)
-    fun `Returns device location`() {
+    fun `Returns device location and its accuracy`() {
         var latlng = 0.0 to 0.0
+        var accuracy = 0F
         val thread = Thread {
             latlng = coordinates.latlng
+            accuracy = coordinates.accuracyInMeters
         }
 
         thread.start()
@@ -67,6 +69,7 @@ class LocationManagerCoordinatesTest {
         thread.join()
 
         latlng.shouldBe(gpsLocation.latitude to gpsLocation.longitude)
+        accuracy.shouldBe(gpsLocation.accuracy)
     }
 
     @Test(timeout = 10_000)

--- a/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinatesTest.kt
+++ b/lib-kmm-geography/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/geography/PermissionAwareCoordinatesTest.kt
@@ -48,5 +48,6 @@ class PermissionAwareCoordinatesTest {
         shadowActivity.grantPermissions(Manifest.permission.ACCESS_FINE_LOCATION)
 
         coordinates.latlng.shouldBe(origin.latlng)
+        coordinates.accuracyInMeters.shouldBe(origin.accuracyInMeters)
     }
 }

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/Coordinates.kt
@@ -20,6 +20,7 @@ package com.hadisatrio.libs.kotlin.geography
 abstract class Coordinates {
 
     abstract val latlng: Pair<Double, Double>
+    abstract val accuracyInMeters: Float
 
     fun distanceTo(other: Coordinates): Distance {
         return Distance(this, other)

--- a/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
+++ b/lib-kmm-geography/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/geography/LiteralCoordinates.kt
@@ -23,6 +23,7 @@ class LiteralCoordinates(
 ) : Coordinates() {
 
     override val latlng: Pair<Double, Double> get() = latitude to longitude
+    override val accuracyInMeters: Float get() = 0F // …assume highest accuracy as we're a literal.
 
     constructor(string: String) : this(
         string.split(',', limit = 2).first().trim().toDouble(),


### PR DESCRIPTION
### What has changed

This patch introduces a dynamic auto-capture vicinity threshold based on the accuracy of the coordinates.  Auto-capture is now skipped if the coordinate accuracy is greater than 50 meters. Additionally, the place is corrected before checking for recency.

### Why it was changed

These changes were implemented to improve the accuracy and efficiency of auto-capture (#313). The previous fixed threshold did not account for coordinate accuracy, potentially leading to duplicate moments being captured. By dynamically adjusting the threshold, we ensure that auto-capture is triggered only when the user is in close proximity to a known place. Correcting the place before the recency check ensures that the appropriate place is used in that check, further enhancing accuracy.