### PR TITLE
Surface writing suggestions

### DIFF
--- a/app-android-journal3/src/main/AndroidManifest.xml
+++ b/app-android-journal3/src/main/AndroidManifest.xml
@@ -102,6 +102,10 @@
         </activity>
 
         <activity
+            android:name=".moment.ViewWritingSuggestionsActivity"
+            android:theme="@style/Theme.Journal3.Translucent" />
+
+        <activity
             android:name=".moment.EditAMomentActivity"
             android:theme="@style/Theme.Journal3.NoActionBar" />
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/ActivityRoutingEventSink.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import com.hadisatrio.apps.android.journal3.geography.SelectAPlaceActivity
 import com.hadisatrio.apps.android.journal3.moment.DeleteAMomentActivity
 import com.hadisatrio.apps.android.journal3.moment.EditAMomentActivity
+import com.hadisatrio.apps.android.journal3.moment.ViewWritingSuggestionsActivity
 import com.hadisatrio.libs.android.foundation.activity.CurrentActivity
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
@@ -38,6 +39,7 @@ class ActivityRoutingEventSink(
         when (identifier) {
             "view_reflections" -> activity.startViewReflectionsActivity()
             "view_story" -> activity.startViewStoryActivity()
+            "view_writing_suggestions" -> activity.startViewWritingSuggestionsActivity()
             "add_moment" -> activity.startAddAMomentActivity(event)
             "edit_moment" -> activity.startEditAMomentActivity(event)
             "delete_moment" -> activity.startDeleteAMomentActivity(event)
@@ -54,6 +56,11 @@ class ActivityRoutingEventSink(
     private fun Activity.startViewStoryActivity() {
         val intent = Intent(this, RootActivity::class.java)
         intent.setAction("view_story")
+        startActivity(intent)
+    }
+
+    private fun Activity.startViewWritingSuggestionsActivity() {
+        val intent = Intent(this, ViewWritingSuggestionsActivity::class.java)
         startActivity(intent)
     }
 

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/Journal3Application.kt
@@ -46,6 +46,7 @@ abstract class Journal3Application : Application() {
     abstract val speed: Speed
     abstract val places: Places
     abstract val story: Story
+    abstract val notableStory: Story
     abstract val reflections: Stories
     abstract val modalPresenter: Presenter<Modal>
     abstract val currentActivity: CurrentActivity

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RealJournal3Application.kt
@@ -42,6 +42,7 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.SentimentAnalyst
 import com.hadisatrio.apps.kotlin.journal3.sentiment.VeryPositiveSentimentRange
 import com.hadisatrio.apps.kotlin.journal3.story.InitDeferringStories
 import com.hadisatrio.apps.kotlin.journal3.story.MomentfulStories
+import com.hadisatrio.apps.kotlin.journal3.story.NotabilityFilteringStory
 import com.hadisatrio.apps.kotlin.journal3.story.Reflection
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
@@ -111,6 +112,10 @@ class RealJournal3Application : Journal3Application() {
         )
     }
 
+    override val notableStory: Story by lazy {
+        NotabilityFilteringStory(notable = true, story)
+    }
+
     private val memorables by lazy {
         MergedMemorables(
             FilesystemMemorablePlaces(
@@ -145,7 +150,7 @@ class RealJournal3Application : Journal3Application() {
                                 origin = VicinityMoments(
                                     coordinates = coordinates,
                                     distanceLimitInM = 100.0,
-                                    origin = story.moments
+                                    origin = notableStory.moments
                                 )
                             )
                         )
@@ -162,7 +167,7 @@ class RealJournal3Application : Journal3Application() {
                                     ),
                                     origin = SentimentRangedMoments(
                                         sentimentRange = PositiveishSentimentRange,
-                                        origin = story.moments
+                                        origin = notableStory.moments
                                     )
                                 )
                             )
@@ -176,7 +181,7 @@ class RealJournal3Application : Journal3Application() {
                             origin = OrderRandomizingMoments(
                                 origin = SentimentRangedMoments(
                                     sentimentRange = VeryPositiveSentimentRange,
-                                    origin = story.moments
+                                    origin = notableStory.moments
                                 )
                             )
                         )
@@ -189,7 +194,7 @@ class RealJournal3Application : Journal3Application() {
                             origin = OrderRandomizingMoments(
                                 origin = SentimentRangedMoments(
                                     sentimentRange = NegativeishSentimentRange,
-                                    origin = story.moments
+                                    origin = notableStory.moments
                                 )
                             )
                         )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/RootActivity.kt
@@ -59,7 +59,7 @@ class RootActivity : AppCompatActivity() {
                 ),
                 ViewClickEventSource(
                     view = findViewById(R.id.add_button),
-                    eventFactory = { SelectionEvent("action", "add_moment") }
+                    eventFactory = { SelectionEvent("action", "view_writing_suggestions") }
                 ),
                 NavigationBarSelectionEventSource(
                     view = bottomBar,

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/geography/SelectAPlaceActivity.kt
@@ -30,7 +30,7 @@ import com.hadisatrio.apps.android.journal3.R
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.geography.SelectAPlaceUseCase
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.android.foundation.activity.ActivityResultSettingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
@@ -116,7 +116,7 @@ class SelectAPlaceActivity : AppCompatActivity() {
                         values
                     }
                 ),
-                ActivityCompletionEventSink(this)
+                ActivityFinishingEventSink(this)
             )
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/DeleteAMomentActivity.kt
@@ -22,7 +22,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.benasher44.uuid.uuidFrom
 import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.moment.DeleteMomentUseCase
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
@@ -48,7 +48,7 @@ class DeleteAMomentActivity : AppCompatActivity() {
                 eventSink = journal3Application.eventSinkDecor.apply(
                     EventSinks(
                         journal3Application.globalEventSink,
-                        ActivityCompletionEventSink(this)
+                        ActivityFinishingEventSink(this)
                     )
                 )
             )

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/EditAMomentActivity.kt
@@ -37,7 +37,7 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.SentimentAnalyzingMoment
 import com.hadisatrio.apps.kotlin.journal3.moment.UpdateDeferringMoment
 import com.hadisatrio.apps.kotlin.journal3.story.EditableMomentInStory
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.material.SliderFloatPresenter
 import com.hadisatrio.libs.android.foundation.material.SliderSelectionEventSource
@@ -179,7 +179,7 @@ class EditAMomentActivity : AppCompatActivity() {
         journal3Application.eventSinkDecor.apply(
             EventSinks(
                 journal3Application.globalEventSink,
-                ActivityCompletionEventSink(this)
+                ActivityFinishingEventSink(this)
             )
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.android.journal3.moment
+
+import android.graphics.Rect
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.grzegorzojdana.spacingitemdecoration.Spacing
+import com.grzegorzojdana.spacingitemdecoration.SpacingItemDecoration
+import com.hadisatrio.apps.android.journal3.R
+import com.hadisatrio.apps.android.journal3.journal3Application
+import com.hadisatrio.apps.android.journal3.sentiment.TextViewColorSentimentPresenter
+import com.hadisatrio.apps.kotlin.journal3.event.RefreshRequestEvent
+import com.hadisatrio.apps.kotlin.journal3.moment.Moment
+import com.hadisatrio.apps.kotlin.journal3.story.NotabilityFilteringStory
+import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
+import com.hadisatrio.apps.kotlin.journal3.story.Story
+import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
+import com.hadisatrio.libs.android.dimensions.dp
+import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
+import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
+import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
+import com.hadisatrio.libs.android.foundation.widget.recyclerview.ListViewPresenter
+import com.hadisatrio.libs.android.foundation.widget.recyclerview.RecyclerViewItemSelectionEventSource
+import com.hadisatrio.libs.android.foundation.widget.recyclerview.ViewFactory
+import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
+import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
+import com.hadisatrio.libs.kotlin.foundation.event.EventSource
+import com.hadisatrio.libs.kotlin.foundation.event.EventSources
+import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.SkippingEventSource
+import com.hadisatrio.libs.kotlin.foundation.presentation.AdaptingPresenter
+import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
+
+class ViewWritingSuggestionsActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        Fragment().show(supportFragmentManager, FRAGMENT_TAG)
+    }
+
+    class Fragment : BottomSheetDialogFragment() {
+
+        private val presenter: Presenter<Story> by lazy {
+            val momentsViewFactory = ViewFactory { parent, _ ->
+                val inflater = LayoutInflater.from(parent.context)
+                val view = inflater.inflate(R.layout.view_moment_horz_card, parent, false)
+                val width = RecyclerView.LayoutParams.MATCH_PARENT
+                val height = RecyclerView.LayoutParams.WRAP_CONTENT
+                val sentimentPresenter = TextViewColorSentimentPresenter(view.findViewById(R.id.sentiment_indicator))
+                view.layoutParams = RecyclerView.LayoutParams(width, height)
+                view.setTag(R.id.presenter_view_tag, sentimentPresenter)
+                view
+            }
+            val momentsPresenter = AdaptingPresenter<Story, Iterable<Moment>>(
+                adapter = { story -> story.moments },
+                origin = ListViewPresenter(
+                    recyclerView = requireView().findViewById(R.id.moments_list),
+                    orientation = RecyclerView.VERTICAL,
+                    viewFactory = momentsViewFactory,
+                    viewRenderer = MomentCardViewRenderer,
+                    differ = MomentItemDiffer,
+                    backgroundExecutor = journal3Application.backgroundExecutor
+                )
+            )
+
+            journal3Application.presenterDecor<Story>().apply(
+                CachingStoryPresenter(
+                    origin = ExecutorDispatchingPresenter(
+                        executor = journal3Application.foregroundExecutor,
+                        origin = momentsPresenter
+                    )
+                )
+            )
+        }
+
+        private val eventSource: EventSource by lazy {
+            journal3Application.eventSourceDecor.apply(
+                EventSources(
+                    journal3Application.globalEventSource,
+                    SkippingEventSource(
+                        count = 1,
+                        origin = LifecycleTriggeredEventSource(
+                            lifecycleOwner = this,
+                            lifecycleEvent = Lifecycle.Event.ON_START,
+                            eventFactory = { RefreshRequestEvent("lifecycle") }
+                        )
+                    ),
+                    LifecycleTriggeredEventSource(
+                        lifecycleOwner = this,
+                        lifecycleEvent = Lifecycle.Event.ON_DESTROY,
+                        eventFactory = { CancellationEvent("system") }
+                    ),
+                    ViewClickEventSource(
+                        view = requireView().findViewById(R.id.add_button),
+                        eventFactory = { SelectionEvent("action", "add_moment") }
+                    ),
+                    RecyclerViewItemSelectionEventSource(
+                        recyclerView = requireView().findViewById(R.id.moments_list)
+                    )
+                )
+            )
+        }
+
+        private val eventSink: EventSink by lazy {
+            journal3Application.eventSinkDecor.apply(
+                EventSinks(
+                    journal3Application.globalEventSink,
+                    ActivityCompletionEventSink(requireActivity())
+                )
+            )
+        }
+
+        private val useCase: UseCase by lazy {
+            journal3Application.useCaseDecor.apply(
+                ShowStoryUseCase(
+                    story = NotabilityFilteringStory(notable = false, journal3Application.story),
+                    presenter = presenter,
+                    eventSource = eventSource,
+                    eventSink = eventSink
+                )
+            )
+        }
+
+        override fun onCreateView(
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
+        ): View? {
+            return inflater.inflate(R.layout.fragment_view_writing_suggestions, container, false)
+        }
+
+        override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+            setupViews()
+            useCase()
+        }
+
+        private fun setupViews() {
+            requireView().findViewById<RecyclerView>(R.id.moments_list).addItemDecoration(
+                SpacingItemDecoration(
+                    Spacing(
+                        edges = Rect(0.dp, 0.dp, 0.dp, 0.dp),
+                        horizontal = 0.dp,
+                        vertical = 8.dp
+                    )
+                )
+            )
+        }
+    }
+
+    companion object {
+        private val FRAGMENT_TAG = "${ViewWritingSuggestionsActivity::class.simpleName}Fragment"
+    }
+}

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
@@ -38,7 +38,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.ViewClickEventSource
@@ -130,7 +130,7 @@ class ViewWritingSuggestionsActivity : AppCompatActivity() {
             journal3Application.eventSinkDecor.apply(
                 EventSinks(
                     journal3Application.globalEventSink,
-                    ActivityCompletionEventSink(requireActivity())
+                    ActivityFinishingEventSink(requireActivity())
                 )
             )
         }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/moment/ViewWritingSuggestionsActivity.kt
@@ -46,6 +46,7 @@ import com.hadisatrio.libs.android.foundation.widget.recyclerview.ListViewPresen
 import com.hadisatrio.libs.android.foundation.widget.recyclerview.RecyclerViewItemSelectionEventSource
 import com.hadisatrio.libs.android.foundation.widget.recyclerview.ViewFactory
 import com.hadisatrio.libs.kotlin.foundation.UseCase
+import com.hadisatrio.libs.kotlin.foundation.event.ActionSelectionEventPredicate
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -130,7 +131,10 @@ class ViewWritingSuggestionsActivity : AppCompatActivity() {
             journal3Application.eventSinkDecor.apply(
                 EventSinks(
                     journal3Application.globalEventSink,
-                    ActivityFinishingEventSink(requireActivity())
+                    ActivityFinishingEventSink(
+                        activity = requireActivity(),
+                        additionalPredicate = ActionSelectionEventPredicate("edit_moment", "add_moment")
+                    )
                 )
             )
         }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/StoriesListFragment.kt
@@ -31,7 +31,7 @@ import com.hadisatrio.apps.android.journal3.journal3Application
 import com.hadisatrio.apps.kotlin.journal3.story.ShowStoriesUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.kotlin.foundation.UseCase
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
 import com.hadisatrio.libs.kotlin.foundation.event.EventSinks
@@ -54,7 +54,7 @@ abstract class StoriesListFragment : Fragment() {
         journal3Application.eventSinkDecor.apply(
             EventSinks(
                 journal3Application.globalEventSink,
-                ActivityCompletionEventSink(requireActivity())
+                ActivityFinishingEventSink(requireActivity())
             )
         )
     }

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryFragment.kt
@@ -125,7 +125,7 @@ class ViewStoryFragment : Fragment() {
     private val useCase: UseCase by lazy {
         journal3Application.useCaseDecor.apply(
             ShowStoryUseCase(
-                story = journal3Application.story,
+                story = journal3Application.notableStory,
                 presenter = presenter,
                 eventSource = eventSource,
                 eventSink = eventSink

--- a/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryFragment.kt
+++ b/app-android-journal3/src/main/kotlin/com/hadisatrio/apps/android/journal3/story/ViewStoryFragment.kt
@@ -38,7 +38,7 @@ import com.hadisatrio.apps.kotlin.journal3.story.ShowStoryUseCase
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.story.cache.CachingStoryPresenter
 import com.hadisatrio.libs.android.dimensions.dp
-import com.hadisatrio.libs.android.foundation.activity.ActivityCompletionEventSink
+import com.hadisatrio.libs.android.foundation.activity.ActivityFinishingEventSink
 import com.hadisatrio.libs.android.foundation.lifecycle.LifecycleTriggeredEventSource
 import com.hadisatrio.libs.android.foundation.presentation.ExecutorDispatchingPresenter
 import com.hadisatrio.libs.android.foundation.widget.recyclerview.ListViewPresenter
@@ -117,7 +117,7 @@ class ViewStoryFragment : Fragment() {
         journal3Application.eventSinkDecor.apply(
             EventSinks(
                 journal3Application.globalEventSink,
-                ActivityCompletionEventSink(requireActivity())
+                ActivityFinishingEventSink(requireActivity())
             )
         )
     }

--- a/app-android-journal3/src/main/res/layout/fragment_view_writing_suggestions.xml
+++ b/app-android-journal3/src/main/res/layout/fragment_view_writing_suggestions.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (C) 2022 Hadi Satrio
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:padding="@dimen/margin">
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/add_button"
+        style="@style/Widget.Material3.Button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="New moment" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/moments_list"
+        android:layout_marginTop="@dimen/margin"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+</LinearLayout>

--- a/app-android-journal3/src/main/res/values/themes.xml
+++ b/app-android-journal3/src/main/res/values/themes.xml
@@ -28,6 +28,7 @@
     </style>
 
     <style name="Theme.Journal3.Translucent" parent="Theme.Journal3">
+        <item name="windowNoTitle">true</item>
         <item name="android:windowIsTranslucent">true</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowContentOverlay">@null</item>

--- a/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
+++ b/app-android-journal3/src/test/kotlin/com/hadisatrio/apps/android/journal3/FakeJournal3Application.kt
@@ -22,6 +22,7 @@ import com.badoo.reaktive.subject.publish.PublishSubject
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import com.hadisatrio.apps.kotlin.journal3.sentiment.DumbSentimentAnalyst
 import com.hadisatrio.apps.kotlin.journal3.sentiment.SentimentAnalyst
+import com.hadisatrio.apps.kotlin.journal3.story.NotabilityFilteringStory
 import com.hadisatrio.apps.kotlin.journal3.story.SelfPopulatingStory
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
@@ -58,6 +59,7 @@ class FakeJournal3Application : Journal3Application() {
     override val speed: Speed by lazy { StaticSpeed(5.0) }
     override val places: Places by lazy { SelfPopulatingPlaces(10, FakePlaces()) }
     override val story: Story by lazy { SelfPopulatingStory(10, FakeStory()) }
+    override val notableStory: Story by lazy { NotabilityFilteringStory(notable = true, story) }
     override val reflections: Stories by lazy { FakeStories() }
     override val modalPresenter: Presenter<Modal> by lazy { FakePresenter() }
     override val currentActivity: CurrentActivity by lazy { CurrentActivity(this) }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -111,6 +111,7 @@ class EditAMomentUseCase(
     }
 
     private fun handleCommitActionSelection() {
+        moment.update(isNotable = true)
         if (isParaphrasingEnabled) {
             DescriptionParaphrasingMoment(paraphraser, moment).commit()
         } else {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/NotabilityFilteringMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/NotabilityFilteringMoments.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.moment
+
+import com.benasher44.uuid.Uuid
+
+class NotabilityFilteringMoments(
+    private val notable: Boolean,
+    private val origin: Moments
+) : Moments {
+
+    override fun count(): Int {
+        return toList().size
+    }
+
+    override fun find(id: Uuid): Iterable<Moment> {
+        return filter { it.id == id }
+    }
+
+    override fun mostRecent(): Moment {
+        return maxBy { it.timestamp }
+    }
+
+    override fun iterator(): Iterator<Moment> {
+        return origin.asSequence().filter { it.isNotable == notable }.iterator()
+    }
+}

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/NotabilityFilteringStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/NotabilityFilteringStory.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.moment.Moments
+import com.hadisatrio.apps.kotlin.journal3.moment.NotabilityFilteringMoments
+
+class NotabilityFilteringStory(
+    private val notable: Boolean,
+    private val origin: Story
+) : Story by origin {
+
+    override val moments: Moments get() {
+        return NotabilityFilteringMoments(notable, origin.moments)
+    }
+}

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCaseTest.kt
@@ -83,6 +83,7 @@ class EditAMomentUseCaseTest {
         moment.sentiment.shouldBe(Sentiment(0.75F))
         moment.place.id.shouldBe(place.id)
         moment.attachments.shouldHaveSize(2)
+        moment.isNotable.shouldBeTrue()
     }
 
     @Test

--- a/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/NotabilityFilteringStoryTest.kt
+++ b/app-kmm-journal3/src/commonTest/kotlin/com/hadisatrio/apps/kotlin/journal3/story/NotabilityFilteringStoryTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.apps.kotlin.journal3.story
+
+import com.hadisatrio.apps.kotlin.journal3.moment.EditableMoment
+import com.hadisatrio.apps.kotlin.journal3.story.fake.FakeStory
+import io.kotest.matchers.shouldBe
+import kotlin.test.Test
+
+class NotabilityFilteringStoryTest {
+
+    @Test
+    fun `Filters moments on basis of their notability`() {
+        val story = SelfPopulatingStory(noOfMoments = 10, FakeStory())
+        (story.moments.first() as EditableMoment).update(isNotable = true)
+
+        val notableCount = NotabilityFilteringStory(notable = true, story).moments.count()
+        val nonNotableCount = NotabilityFilteringStory(notable = false, story).moments.count()
+
+        notableCount.shouldBe(1)
+        nonNotableCount.shouldBe(9)
+    }
+}

--- a/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityFinishingEventSink.kt
+++ b/lib-kmm-foundation/src/androidMain/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityFinishingEventSink.kt
@@ -21,13 +21,15 @@ import android.app.Activity
 import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.EventSink
+import com.hadisatrio.libs.kotlin.foundation.event.Predicate
 
-class ActivityCompletionEventSink(
-    private val activity: Activity
+class ActivityFinishingEventSink(
+    private val activity: Activity,
+    private val additionalPredicate: Predicate<Event> = Predicate { false }
 ) : EventSink {
 
     override fun sink(event: Event) {
-        if (event !is CompletionEvent) return
+        if (event !is CompletionEvent && !additionalPredicate.applicable(event)) return
         if (activity.isFinishing || activity.isChangingConfigurations) return
         activity.finish()
     }

--- a/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityFinishingEventSinkTest.kt
+++ b/lib-kmm-foundation/src/androidUnitTest/kotlin/com/hadisatrio/libs/android/foundation/activity/ActivityFinishingEventSinkTest.kt
@@ -21,8 +21,10 @@ import androidx.activity.ComponentActivity
 import androidx.test.runner.AndroidJUnit4
 import com.hadisatrio.libs.kotlin.foundation.event.CancellationEvent
 import com.hadisatrio.libs.kotlin.foundation.event.CompletionEvent
+import com.hadisatrio.libs.kotlin.foundation.event.Event
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.event.TextInputEvent
+import com.hadisatrio.libs.kotlin.foundation.event.fake.FakeEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
 import io.mockk.every
 import io.mockk.spyk
@@ -33,11 +35,12 @@ import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
-class ActivityCompletionEventSinkTest {
+class ActivityFinishingEventSinkTest {
 
     private val activityController = Robolectric.buildActivity(ComponentActivity::class.java)
     private val activity = spyk(activityController.get())
-    private val eventSink = ActivityCompletionEventSink(activity)
+    private val additionalPredicate = { event: Event -> event is FakeEvent }
+    private val eventSink = ActivityFinishingEventSink(activity, additionalPredicate)
 
     @Before
     fun `Starts activity`() {
@@ -47,6 +50,12 @@ class ActivityCompletionEventSinkTest {
     @Test
     fun `Finishes the activity upon receiving a completion event`() {
         eventSink.sink(CompletionEvent())
+        verify(exactly = 1) { activity.finish() }
+    }
+
+    @Test
+    fun `Finishes the activity upon receiving an event matching the given predicate`() {
+        eventSink.sink(FakeEvent())
         verify(exactly = 1) { activity.finish() }
     }
 

--- a/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ActionSelectionEventPredicate.kt
+++ b/lib-kmm-foundation/src/commonMain/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ActionSelectionEventPredicate.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+class ActionSelectionEventPredicate(
+    private val identifiers: Set<String>
+) : Predicate<Event> {
+
+    constructor(vararg identifiers: String) : this(identifiers.toSet())
+
+    override fun applicable(thing: Event): Boolean {
+        val selection = (thing as? SelectionEvent) ?: return false
+        val isAction = selection.selectionKind == "action"
+        val idMatches = selection.selectedIdentifier in identifiers
+        return isAction && idMatches
+    }
+}

--- a/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ActionSelectionEventPredicateTest.kt
+++ b/lib-kmm-foundation/src/commonTest/kotlin/com/hadisatrio/libs/kotlin/foundation/event/ActionSelectionEventPredicateTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 Hadi Satrio
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.hadisatrio.libs.kotlin.foundation.event
+
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import kotlin.test.Test
+
+class ActionSelectionEventPredicateTest {
+
+    @Test
+    fun `Matches only action selection events with the given identifier`() {
+        val identifiers = setOf("one", "another")
+        val events = identifiers.map { SelectionEvent("action", it) }
+
+        val predicate = ActionSelectionEventPredicate(identifiers)
+
+        events.forEach { event -> predicate.applicable(event).shouldBeTrue() }
+        predicate.applicable(SelectionEvent("action", "unknown")).shouldBeFalse()
+        predicate.applicable(SelectionEvent("not_action", "one")).shouldBeFalse()
+    }
+}


### PR DESCRIPTION
### What has changed

#### Notability of `Moment`s

Notability of moments has now been fully-fleshed out. Through `EditAMomentUseCase`, we now mark moments the user has explicitly created or edited as notable; drawing a distinction from the ones created by the system via `CaptureAMomentUseCase` (see: #313). With this in place, we have also hidden non-notable moments from all existing screens.

#### Writing suggestions

Non-notable moments are now shown in a new screen, `ViewWritingSuggestionsActivity`, as writing suggestions for the user. This screen lives in between the root and the moment editor, allowing the user the chance to annotate an automatically-captured moment rather than starting from scratch.

### Why was it changed

Because I was inspired by Apple Journal.