### PR TITLE
Add comprehensive KDoc documentation to public APIs (cont'd)

### DIFF
--- a/app-kmm-journal3/src/androidMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestamp.kt
+++ b/app-kmm-journal3/src/androidMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/FormattedTimestamp.kt
@@ -23,11 +23,19 @@ import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
+/**
+ * A [Timestamp] decorator whose [toString] returns the underlying instant
+ * formatted by a [DateFormat].
+ */
 class FormattedTimestamp(
     private val formatter: DateFormat,
     private val origin: Timestamp
 ) : Timestamp by origin {
 
+    /**
+     * Constructs a [FormattedTimestamp] using a [SimpleDateFormat] built from
+     * [format], [locale], and [timeZone].
+     */
     constructor(
         locale: Locale,
         timeZone: TimeZone,
@@ -35,6 +43,9 @@ class FormattedTimestamp(
         origin: Timestamp
     ) : this(SimpleDateFormat(format, locale).apply { this.timeZone = timeZone }, origin)
 
+    /**
+     * Constructs a [FormattedTimestamp] using the device's default locale and time zone.
+     */
     constructor(
         format: String,
         origin: Timestamp

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/alert/AlertInactivityUseCase.kt
@@ -32,6 +32,10 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import kotlinx.datetime.Clock
 import kotlin.time.Duration
 
+/**
+ * A [UseCase] that prompts the user to log a new moment when no entry has been
+ * recorded within the configured inactivity [threshold].
+ */
 class AlertInactivityUseCase(
     private val threshold: Duration,
     private val moments: Moments,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/LiteralTimestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/LiteralTimestamp.kt
@@ -19,12 +19,21 @@ package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
 
+/**
+ * A [Timestamp] backed directly by a kotlinx [Instant] value.
+ */
 data class LiteralTimestamp(
     override val value: Instant
 ) : Timestamp {
 
+    /**
+     * Constructs a [LiteralTimestamp] by parsing an ISO-8601 string.
+     */
     constructor(iso8601: String) : this(Instant.parse(iso8601))
 
+    /**
+     * Constructs a [LiteralTimestamp] from milliseconds since the Unix epoch.
+     */
     constructor(epochMilliseconds: Long) : this(Instant.fromEpochMilliseconds(epochMilliseconds))
 
     override fun toString(): String {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/Timestamp.kt
@@ -20,18 +20,30 @@ package com.hadisatrio.apps.kotlin.journal3.datetime
 import kotlinx.datetime.Instant
 import kotlin.time.Duration
 
+/**
+ * A point in time with calendar arithmetic and formatting capabilities.
+ */
 interface Timestamp : Comparable<Timestamp> {
 
     val value: Instant
 
+    /**
+     * Returns the number of milliseconds since the Unix epoch.
+     */
     fun toEpochMilliseconds(): Long {
         return value.toEpochMilliseconds()
     }
 
+    /**
+     * Returns the signed [Duration] between this timestamp and [other].
+     */
     fun difference(other: Timestamp): Duration {
         return this.value - other.value
     }
 
+    /**
+     * Returns a new [Timestamp] shifted earlier by [duration].
+     */
     operator fun minus(duration: Duration): Timestamp {
         return LiteralTimestamp(value - duration)
     }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/UnixEpoch.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/datetime/UnixEpoch.kt
@@ -19,6 +19,11 @@ package com.hadisatrio.apps.kotlin.journal3.datetime
 
 import kotlinx.datetime.Instant
 
+/**
+ * A [Timestamp] representing the Unix epoch (1970-01-01T00:00:00Z).
+ *
+ * Useful as a sentinel "no timestamp" value.
+ */
 object UnixEpoch : Timestamp {
 
     override val value: Instant = Instant.fromEpochMilliseconds(0)

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/event/RefreshRequestEvent.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/event/RefreshRequestEvent.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.event
 
 import com.hadisatrio.libs.kotlin.foundation.event.Event
 
+/**
+ * An [Event] signalling that a consumer should reload its data from the source of truth.
+ */
 class RefreshRequestEvent(
     private val reason: String
 ) : Event() {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/forgettable/DeleteForgettableUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/forgettable/DeleteForgettableUseCase.kt
@@ -27,6 +27,12 @@ import com.hadisatrio.libs.kotlin.foundation.modal.ModalApprovalEvent
 import com.hadisatrio.libs.kotlin.foundation.modal.ModalDismissalEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A base [UseCase] that presents a confirmation dialog before deleting a [Forgettable].
+ *
+ * Subclasses supply the target [Forgettable] via [forgettable]; the base class handles
+ * the confirmation modal and calls [Forgettable.forget] upon user approval.
+ */
 abstract class DeleteForgettableUseCase(
     private val presenter: Presenter<Modal>,
     eventSource: EventSource,
@@ -37,6 +43,9 @@ abstract class DeleteForgettableUseCase(
         present()
     }
 
+    /**
+     * Returns the [Forgettable] to be deleted, or `null` if it cannot be found.
+     */
     abstract fun forgettable(): Forgettable?
 
     private fun present() {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/forgettable/Forgettable.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/forgettable/Forgettable.kt
@@ -17,6 +17,13 @@
 
 package com.hadisatrio.apps.kotlin.journal3.forgettable
 
+/**
+ * A resource that can be permanently deleted on demand.
+ */
 fun interface Forgettable {
+
+    /**
+     * Permanently deletes this resource. The operation is irreversible.
+     */
     fun forget()
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/geography/SelectAPlaceUseCase.kt
@@ -34,6 +34,10 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.Places
 
+/**
+ * A [UseCase] that presents a searchable list of [Place]s and sinks a selection event
+ * once the user picks one.
+ */
 class SelectAPlaceUseCase(
     private val places: Places,
     private val presenter: Presenter<Iterable<Place>>,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/id/InvalidUuid.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/id/InvalidUuid.kt
@@ -19,4 +19,5 @@ package com.hadisatrio.apps.kotlin.journal3.id
 
 import com.benasher44.uuid.uuidFrom
 
+/** A sentinel UUID (all-zeros) representing an absent or unresolved identifier. */
 val INVALID_UUID = uuidFrom("00000000-0000-0000-0000-000000000000")

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CaptureAMomentUseCase.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.libs.kotlin.geography.Speed
 import kotlinx.datetime.Clock
 import kotlin.time.Duration.Companion.hours
 
+/**
+ * A [UseCase] that silently logs a new moment at the current location when the device
+ * is stationary, coordinates are accurate, and no moment has been recorded nearby today.
+ */
 class CaptureAMomentUseCase(
     private val moments: EditableMoments,
     private val currentPlace: Place,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/ClockRespectingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/ClockRespectingMoment.kt
@@ -21,6 +21,10 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 import kotlinx.datetime.Clock
 
+/**
+ * An [EditableMoment] decorator that auto-populates [timestamp] from the system clock
+ * the first time it is read on a newly created, unedited moment.
+ */
 class ClockRespectingMoment(
     private val clock: Clock,
     private val origin: EditableMoment

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/CountLimitingMoments.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A [Moments] view that surfaces at most [limit] entries from an underlying collection.
+ */
 class CountLimitingMoments(
     private val limit: Int,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DeleteMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DeleteMomentUseCase.kt
@@ -25,6 +25,10 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.modal.Modal
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [UseCase] that presents a confirmation dialog and deletes the moment identified
+ * by [momentId] upon user approval.
+ */
 class DeleteMomentUseCase(
     private val momentId: Uuid,
     private val moments: Moments,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/DescriptionParaphrasingMoment.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
 
+/**
+ * An [EditableMoment] decorator that rewrites the description through a [Paraphraser]
+ * before delegating to the underlying [commit].
+ */
 class DescriptionParaphrasingMoment(
     private val paraphraser: Paraphraser,
     private val origin: EditableMoment

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditAMomentUseCase.kt
@@ -39,6 +39,11 @@ import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 import com.hadisatrio.libs.kotlin.geography.Places
 import com.hadisatrio.libs.kotlin.paraphrase.Paraphraser
 
+/**
+ * A [UseCase] that presents a [Moment] for editing and persists changes on user confirmation.
+ *
+ * If the target moment is newly created and the user cancels, it is discarded automatically.
+ */
 @Suppress(
     "LongParameterList",
     "TooManyFunctions"

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMoment.kt
@@ -23,14 +23,53 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
 
+/**
+ * A [Moment] whose fields can be mutated and persisted via [commit].
+ */
 interface EditableMoment : Moment {
+
+    /**
+     * Returns `true` if this moment was just created and has not yet been committed.
+     */
     fun isNewlyCreated(): Boolean
+
+    /**
+     * Stages a new [timestamp] for this moment.
+     */
     fun update(timestamp: Timestamp)
+
+    /**
+     * Stages a new [description] for this moment.
+     */
     fun update(description: TokenableString)
+
+    /**
+     * Stages a new [sentiment] score for this moment.
+     */
     fun update(sentiment: Sentiment)
+
+    /**
+     * Stages a new [place] for this moment.
+     */
     fun update(place: Place)
+
+    /**
+     * Stages a new set of media [attachments] for this moment.
+     */
     fun update(attachments: Iterable<Uri>)
+
+    /**
+     * Stages a new notability flag for this moment.
+     */
     fun update(isNotable: Boolean)
+
+    /**
+     * Returns `true` if any staged updates differ from the currently persisted values.
+     */
     fun updatesMade(): Boolean
+
+    /**
+     * Persists all staged updates to the backing store.
+     */
     fun commit()
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMomentInMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMomentInMoments.kt
@@ -25,6 +25,10 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
 
+/**
+ * An [EditableMoment] that lazily resolves its target from an [EditableMoments] collection,
+ * creating a new moment when [targetId] equals [INVALID_UUID].
+ */
 @Suppress("TooManyFunctions")
 class EditableMomentInMoments(
     private val targetId: Uuid,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/EditableMoments.kt
@@ -17,6 +17,13 @@
 
 package com.hadisatrio.apps.kotlin.journal3.moment
 
+/**
+ * A [Moments] collection that supports creating new [EditableMoment]s.
+ */
 interface EditableMoments : Moments {
+
+    /**
+     * Creates and returns a new, empty [EditableMoment] backed by this collection.
+     */
     fun new(): EditableMoment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Memorable.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Memorable.kt
@@ -19,9 +19,24 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A linkable resource that can be associated with one or more [Moment]s.
+ */
 interface Memorable {
     val id: Uuid
+
+    /**
+     * Associates this resource with the moment identified by [momentId].
+     */
     fun link(momentId: Uuid)
+
+    /**
+     * Removes the association between this resource and the moment identified by [momentId].
+     */
     fun unlink(momentId: Uuid)
+
+    /**
+     * Returns `true` if this resource is associated with the moment identified by [momentId].
+     */
     fun relevantTo(momentId: Uuid): Boolean
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MemorableFile.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MemorableFile.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.chrynan.uri.core.Uri
 
+/**
+ * A [Memorable] representing a media file attached to a moment, identified by its [Uri].
+ */
 interface MemorableFile : Memorable {
     val uri: Uri
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MemorablePlace.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MemorablePlace.kt
@@ -20,12 +20,31 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.hadisatrio.libs.kotlin.geography.Coordinates
 import com.hadisatrio.libs.kotlin.geography.Place
 
+/**
+ * A [Place] that is also [Memorable] and whose details can be updated after creation.
+ */
 interface MemorablePlace : Place, Memorable {
 
+    /** A human-readable label displayed in the UI for this place. */
     val label: String
 
+    /**
+     * Updates the display [label] of this place.
+     */
     fun updateLabel(label: String)
+
+    /**
+     * Updates the proper name of this place.
+     */
     fun updateName(name: String)
+
+    /**
+     * Updates the street address of this place.
+     */
     fun updateAddress(address: String)
+
+    /**
+     * Updates the geographic [coordinates] of this place.
+     */
     fun update(coordinates: Coordinates)
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Memorables.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Memorables.kt
@@ -19,8 +19,24 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A collection of [Memorable] resources that can be queried by moment association.
+ */
 interface Memorables : Iterable<Memorable> {
+
+    /**
+     * Records [thing] as a [Memorable] linked to the moment identified by [momentId],
+     * creating the internal representation if necessary.
+     */
     fun relate(momentId: Uuid, thing: Any)
+
+    /**
+     * Returns all [Memorable]s whose id matches [id].
+     */
     fun find(id: Uuid): Iterable<Memorable>
+
+    /**
+     * Returns all [Memorable]s associated with the moment identified by [momentId].
+     */
     fun relevantTo(momentId: Uuid): Iterable<Memorable>
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MentionedPerson.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MentionedPerson.kt
@@ -19,9 +19,16 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.hadisatrio.apps.kotlin.journal3.token.Token
 
+/**
+ * A [Memorable] representing a person mentioned in a moment's text via their '@' [slug].
+ */
 interface MentionedPerson : Memorable {
+    /** The '@'-prefixed token used to reference this person in journal text. */
     val slug: Token
     val name: String
 
+    /**
+     * Updates the display name of this person.
+     */
     fun update(name: String)
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorables.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMemorables.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A [Memorables] that combines multiple [Memorables] collections into a single unified view.
+ */
 class MergedMemorables(
     private val collection: Iterable<Memorables>
 ) : Memorables {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/MergedMoments.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A [Moments] that combines multiple [Moments] collections into a single unified view.
+ */
 class MergedMoments(private val moments: Iterable<Moments>) : Moments {
 
     constructor(vararg moments: Moments) : this(moments.toList())

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moment.kt
@@ -25,6 +25,10 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
 
+/**
+ * A journal entry capturing a specific point in time, described by location,
+ * sentiment, free-form text, and optional media attachments.
+ */
 interface Moment : Comparable<Moment>, Forgettable {
     val id: Uuid
     val timestamp: Timestamp
@@ -32,5 +36,7 @@ interface Moment : Comparable<Moment>, Forgettable {
     val sentiment: Sentiment
     val place: Place
     val attachments: Iterable<Uri>
+
+    /** Whether this moment is flagged as particularly worth remembering. */
     val isNotable: Boolean
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/Moments.kt
@@ -19,11 +19,23 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A queryable, iterable collection of [Moment]s.
+ */
 interface Moments : Iterable<Moment> {
 
+    /**
+     * Returns the total number of moments in this collection.
+     */
     fun count(): Int
 
+    /**
+     * Returns all moments whose [Moment.id] matches [id].
+     */
     fun find(id: Uuid): Iterable<Moment>
 
+    /**
+     * Returns the moment with the latest [Moment.timestamp] in this collection.
+     */
     fun mostRecent(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/NotabilityFilteringMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/NotabilityFilteringMoments.kt
@@ -19,6 +19,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import com.benasher44.uuid.Uuid
 
+/**
+ * A [Moments] view that filters the underlying collection to only those moments
+ * whose [Moment.isNotable] flag matches [notable].
+ */
 class NotabilityFilteringMoments(
     private val notable: Boolean,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/OrderRandomizingMoments.kt
@@ -19,6 +19,9 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 
 import kotlin.random.Random
 
+/**
+ * A [Moments] decorator that returns moments in a randomized order on each iteration.
+ */
 class OrderRandomizingMoments(
     private val random: Random,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SelfPopulatingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SelfPopulatingMoments.kt
@@ -21,6 +21,10 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import kotlinx.datetime.Clock
 
+/**
+ * An [EditableMoments] decorator that pre-populates the underlying collection with
+ * [noOfMoments] placeholder moments on construction.
+ */
 class SelfPopulatingMoments(
     noOfMoments: Int,
     private val origin: EditableMoments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentAnalyzingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentAnalyzingMoment.kt
@@ -21,6 +21,10 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.sentiment.SentimentAnalyst
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
+/**
+ * An [EditableMoment] decorator that derives [Moment.sentiment] automatically from the
+ * description text and trains the [SentimentAnalyst] when the user explicitly overrides it.
+ */
 class SentimentAnalyzingMoment(
     private val analyst: SentimentAnalyst,
     private val origin: EditableMoment

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/SentimentRangedMoments.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 
+/**
+ * A [Moments] view that filters the underlying collection to only those moments
+ * whose [Moment.sentiment] falls within [sentimentRange].
+ */
 class SentimentRangedMoments(
     private val sentimentRange: ClosedRange<Sentiment>,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/ShowMomentsUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/ShowMomentsUseCase.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [UseCase] that presents a [Moments] collection and routes item-selection and
+ * add-action events to the appropriate downstream handlers.
+ */
 class ShowMomentsUseCase(
     private val moments: Moments,
     private val presenter: Presenter<Moments>,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/TimeRangedMoments.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment
 import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.datetime.Timestamp
 
+/**
+ * A [Moments] view that filters the underlying collection to only those moments
+ * whose [Moment.timestamp] falls within [timeRange].
+ */
 class TimeRangedMoments(
     private val timeRange: ClosedRange<Timestamp>,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/UpdateDeferringMoment.kt
@@ -23,6 +23,10 @@ import com.hadisatrio.apps.kotlin.journal3.sentiment.Sentiment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
 
+/**
+ * An [EditableMoment] decorator that holds all field updates in memory and writes them
+ * to the underlying moment only when [commit] is called.
+ */
 class UpdateDeferringMoment(
     private val origin: EditableMoment
 ) : EditableMoment by origin {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/VicinityMoments.kt
@@ -21,6 +21,12 @@ import com.benasher44.uuid.Uuid
 import com.hadisatrio.libs.kotlin.geography.Coordinates
 import com.hadisatrio.libs.kotlin.geography.NullIsland
 
+/**
+ * A [Moments] view that filters the underlying collection to only those moments
+ * recorded at a place within [distanceLimitInM] metres of [coordinates].
+ *
+ * Moments with no real place (i.e. [NullIsland]) are always excluded.
+ */
 class VicinityMoments(
     private val coordinates: Coordinates,
     private val distanceLimitInM: Double,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoment.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import com.hadisatrio.libs.kotlin.geography.Place
 import com.hadisatrio.libs.kotlin.geography.cache.CachingPlace
 
+/**
+ * A [Moment] decorator that eagerly copies all property values from [origin] into fields,
+ * shielding callers from repeated or costly underlying reads.
+ */
 @Suppress("LongParameterList")
 class CachingMoment(
     override val id: Uuid,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMoments.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment.cache
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 
+/**
+ * A [Moments] decorator that wraps each iterated moment with a [CachingMoment] and
+ * pre-computes the count, reducing repeat reads from the underlying collection.
+ */
 class CachingMoments private constructor(
     private val count: Int,
     private val origin: Moments

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMomentsPresenter.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/cache/CachingMomentsPresenter.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.moment.cache
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [Presenter] decorator that wraps the presented [Moments] in a [CachingMoments]
+ * before forwarding to the underlying presenter.
+ */
 class CachingMomentsPresenter(
     private val origin: Presenter<Moments>
 ) : Presenter<Moments> {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFile.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFile.kt
@@ -30,6 +30,10 @@ import kotlinx.serialization.json.jsonArray
 import okio.FileSystem
 import okio.Path
 
+/**
+ * A [MemorableFile] backed by a file on the filesystem, tracking moment associations
+ * in a sibling JSON attributes file.
+ */
 class FilesystemMemorableFile(
     private val fileSystem: FileSystem,
     private val path: Path

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFiles.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorableFiles.kt
@@ -27,6 +27,10 @@ import okio.FileSystem
 import okio.Path
 import okio.buffer
 
+/**
+ * A [Memorables] that persists media file attachments in a directory on the filesystem,
+ * deduplicating files by content hash.
+ */
 class FilesystemMemorableFiles(
     private val sources: Sources,
     private val fileSystem: FileSystem,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlace.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlace.kt
@@ -30,6 +30,10 @@ import kotlinx.serialization.json.jsonArray
 import okio.FileSystem
 import okio.Path
 
+/**
+ * A [MemorablePlace] backed by a JSON file on the filesystem, persisting place details
+ * and moment associations between sessions.
+ */
 class FilesystemMemorablePlace(
     private val file: JsonFile
 ) : MemorablePlace {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaces.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMemorablePlaces.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.libs.kotlin.geography.Place
 import okio.FileSystem
 import okio.Path
 
+/**
+ * A [Memorables] that persists geographic places in a directory on the filesystem,
+ * associating each place with the moments that occurred there.
+ */
 class FilesystemMemorablePlaces(
     private val fileSystem: FileSystem,
     private val path: Path

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMentionedPeople.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMentionedPeople.kt
@@ -27,6 +27,10 @@ import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import okio.FileSystem
 import okio.Path
 
+/**
+ * A [Memorables] that persists mentioned people in a directory on the filesystem,
+ * keying records by '@'-prefixed slug tokens extracted from moment descriptions.
+ */
 class FilesystemMentionedPeople(
     private val fileSystem: FileSystem,
     private val path: Path

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMentionedPerson.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMentionedPerson.kt
@@ -29,6 +29,10 @@ import kotlinx.serialization.json.jsonArray
 import okio.FileSystem
 import okio.Path
 
+/**
+ * A [MentionedPerson] backed by a JSON file on the filesystem, persisting the person's
+ * slug, name, and moment associations between sessions.
+ */
 class FilesystemMentionedPerson(
     private val file: JsonFile
 ) : MentionedPerson {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoment.kt
@@ -38,6 +38,10 @@ import kotlinx.serialization.json.jsonPrimitive
 import okio.FileSystem
 import okio.Path
 
+/**
+ * An [EditableMoment] that persists all fields directly to a JSON file on the filesystem.
+ * Field updates are written immediately; [commit] is a no-op.
+ */
 @Suppress("TooManyFunctions")
 class FilesystemMoment(
     private val file: JsonFile,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/moment/filesystem/FilesystemMoments.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import okio.FileSystem
 import okio.Path
 
+/**
+ * An [EditableMoments] that stores each moment as a JSON file within a directory,
+ * iterating them in descending chronological order.
+ */
 class FilesystemMoments(
     private val fileSystem: FileSystem,
     private val path: Path,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/DumbSentimentAnalyst.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/DumbSentimentAnalyst.kt
@@ -17,6 +17,9 @@
 
 package com.hadisatrio.apps.kotlin.journal3.sentiment
 
+/**
+ * A [SentimentAnalyst] that uses a fixed keyword list and ignores any training data.
+ */
 object DumbSentimentAnalyst : SentimentAnalyst {
 
     private val positiveWords: Set<String> = setOf(

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/InitDeferringSentimentAnalyst.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/InitDeferringSentimentAnalyst.kt
@@ -17,6 +17,10 @@
 
 package com.hadisatrio.apps.kotlin.journal3.sentiment
 
+/**
+ * A [SentimentAnalyst] decorator that delays instantiation of the underlying analyst
+ * until its first use.
+ */
 class InitDeferringSentimentAnalyst(
     private val provider: () -> SentimentAnalyst
 ) : SentimentAnalyst {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/Sentiment.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/Sentiment.kt
@@ -19,11 +19,22 @@ package com.hadisatrio.apps.kotlin.journal3.sentiment
 
 import kotlin.jvm.JvmInline
 
+/**
+ * A normalized emotional score between 0.0 (very negative) and 1.0 (very positive).
+ *
+ * @throws IllegalArgumentException if [value] is outside the range [0.0, 1.0].
+ */
 @JvmInline
 value class Sentiment(val value: Float) : Comparable<Sentiment> {
 
+    /**
+     * Constructs a [Sentiment] by parsing [value] as a float.
+     */
     constructor(value: String) : this(value.toFloat())
 
+    /**
+     * Constructs a [Sentiment] whose score is the mean of all scores in [others].
+     */
     constructor(others: Iterable<Sentiment>) : this(others.map { it.value }.average().toFloat())
 
     init {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentAnalyst.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentAnalyst.kt
@@ -17,7 +17,18 @@
 
 package com.hadisatrio.apps.kotlin.journal3.sentiment
 
+/**
+ * An analyst that scores text with a [Sentiment] value.
+ */
 interface SentimentAnalyst {
+
+    /**
+     * Supplies known word-to-sentiment [relationships] to improve analysis accuracy.
+     */
     fun train(relationships: Map<String, Sentiment>)
+
+    /**
+     * Returns a [Sentiment] score for the given [string].
+     */
     fun analyze(string: String): Sentiment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentRanges.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/sentiment/SentimentRanges.kt
@@ -19,36 +19,43 @@
 
 package com.hadisatrio.apps.kotlin.journal3.sentiment
 
+/** A [ClosedRange] covering very positive sentiment scores (0.81–1.0). */
 object VeryPositiveSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(1.0F)
     override val start: Sentiment = Sentiment(0.81F)
 }
 
+/** A [ClosedRange] covering positive sentiment scores (0.56–0.80). */
 object PositiveSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(0.80F)
     override val start: Sentiment = Sentiment(0.56F)
 }
 
+/** A [ClosedRange] covering neutral sentiment scores (0.45–0.55). */
 object NeutralSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(0.55F)
     override val start: Sentiment = Sentiment(0.45F)
 }
 
+/** A [ClosedRange] covering negative sentiment scores (0.20–0.44). */
 object NegativeSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(0.44F)
     override val start: Sentiment = Sentiment(0.20F)
 }
 
+/** A [ClosedRange] covering very negative sentiment scores (0.0–0.19). */
 object VeryNegativeSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(0.19F)
     override val start: Sentiment = Sentiment(0.0F)
 }
 
+/** A [ClosedRange] covering broadly positive sentiment scores (0.61–1.0). */
 object PositiveishSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(1.0F)
     override val start: Sentiment = Sentiment(0.61F)
 }
 
+/** A [ClosedRange] covering broadly negative sentiment scores (0.0–0.39). */
 object NegativeishSentimentRange : ClosedRange<Sentiment> {
     override val endInclusive: Sentiment = Sentiment(0.39F)
     override val start: Sentiment = Sentiment(0.0F)

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditableStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/EditableStory.kt
@@ -21,9 +21,28 @@ import com.hadisatrio.apps.kotlin.journal3.forgettable.Forgettable
 import com.hadisatrio.apps.kotlin.journal3.moment.EditableMoment
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
+/**
+ * A [Story] whose title, synopsis, and moments can be mutated.
+ */
 interface EditableStory : Story, Forgettable {
+
+    /**
+     * Returns `true` if this story was just created and has not yet been persisted.
+     */
     fun isNewlyCreated(): Boolean
+
+    /**
+     * Updates the title of this story.
+     */
     fun update(title: String)
+
+    /**
+     * Updates the synopsis of this story.
+     */
     fun update(synopsis: TokenableString)
+
+    /**
+     * Creates and returns a new [EditableMoment] belonging to this story.
+     */
     fun new(): EditableMoment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/InitDeferringStories.kt
@@ -21,6 +21,10 @@ import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 
+/**
+ * A [Stories] decorator that delays instantiation of the underlying repository
+ * until its first use.
+ */
 class InitDeferringStories(
     private val provider: () -> Stories
 ) : Stories {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/MomentfulStories.kt
@@ -17,6 +17,9 @@
 
 package com.hadisatrio.apps.kotlin.journal3.story
 
+/**
+ * A [Stories] decorator that filters out stories containing no moments during iteration.
+ */
 class MomentfulStories(
     private val origin: Stories
 ) : Stories by origin {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Reflection.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Reflection.kt
@@ -21,6 +21,10 @@ import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
+/**
+ * A [Story] whose [id] is derived deterministically from its [title], intended for
+ * synthetic or computed groupings of moments rather than user-created narratives.
+ */
 class Reflection(
     override val title: String,
     override val synopsis: TokenableString,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/SelfPopulatingStories.kt
@@ -21,6 +21,10 @@ import com.hadisatrio.apps.kotlin.journal3.datetime.LiteralTimestamp
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 import kotlinx.datetime.Clock
 
+/**
+ * A [Stories] decorator that pre-populates the underlying repository with [noOfStories]
+ * placeholder stories, each containing [noOfMoments] placeholder moments, on construction.
+ */
 class SelfPopulatingStories(
     private val noOfStories: Int,
     private val noOfMoments: Int,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoriesUseCase.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/ShowStoriesUseCase.kt
@@ -26,6 +26,10 @@ import com.hadisatrio.libs.kotlin.foundation.event.EventSource
 import com.hadisatrio.libs.kotlin.foundation.event.SelectionEvent
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [UseCase] that presents a [Stories] collection and routes item-selection events
+ * to the appropriate downstream handlers.
+ */
 class ShowStoriesUseCase(
     private val stories: Stories,
     private val presenter: Presenter<Stories>,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Stories.kt
@@ -21,20 +21,46 @@ import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.moment.Moment
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 
+/**
+ * A repository of [Story] objects that also provides unified cross-story [Moment] access.
+ */
 interface Stories : Iterable<Story> {
+
+    /** A unified view of all moments across every story in this repository. */
     val moments: Moments
 
+    /**
+     * Creates and returns a new, empty [EditableStory] backed by this repository.
+     */
     fun new(): EditableStory
 
+    /**
+     * Returns `true` if a story with the given [id] exists in this repository.
+     */
     fun containsStory(id: Uuid): Boolean
 
+    /**
+     * Returns all stories whose id matches [id].
+     */
     fun findStory(id: Uuid): Iterable<Story>
 
+    /**
+     * Returns `true` if any story in this repository contains at least one moment.
+     */
     fun hasMoments(): Boolean
 
+    /**
+     * Returns `true` if a moment with the given [id] exists across all stories.
+     */
     fun containsMoment(id: Uuid): Boolean
 
+    /**
+     * Returns all moments whose id matches [id] across all stories.
+     */
     fun findMoment(id: Uuid): Iterable<Moment>
 
+    /**
+     * Returns the most recently timestamped moment across all stories.
+     */
     fun mostRecentMoment(): Moment
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/Story.kt
@@ -21,9 +21,14 @@ import com.benasher44.uuid.Uuid
 import com.hadisatrio.apps.kotlin.journal3.moment.Moments
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
+/**
+ * A named narrative that groups a set of related [Moments] under a shared title and synopsis.
+ */
 interface Story : Comparable<Story> {
     val id: Uuid
     val title: String
     val synopsis: TokenableString
+
+    /** The collection of moments belonging to this story. */
     val moments: Moments
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStories.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStories.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.story.cache
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 
+/**
+ * A [Stories] decorator that wraps each iterated story with a [CachingStory],
+ * reducing repeat reads from the underlying collection.
+ */
 class CachingStories(
     private val origin: Stories
 ) : Stories by origin {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStoriesPresenter.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStoriesPresenter.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.story.cache
 import com.hadisatrio.apps.kotlin.journal3.story.Stories
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [Presenter] decorator that wraps the presented [Stories] in a [CachingStories]
+ * before forwarding to the underlying presenter.
+ */
 class CachingStoriesPresenter(
     private val origin: Presenter<Stories>
 ) : Presenter<Stories> {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStory.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStory.kt
@@ -23,6 +23,10 @@ import com.hadisatrio.apps.kotlin.journal3.moment.cache.CachingMoments
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.apps.kotlin.journal3.token.TokenableString
 
+/**
+ * A [Story] decorator that eagerly copies all property values from [origin] into fields,
+ * shielding callers from repeated or costly underlying reads.
+ */
 class CachingStory(
     override val id: Uuid,
     override val title: String,

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStoryPresenter.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/story/cache/CachingStoryPresenter.kt
@@ -20,6 +20,10 @@ package com.hadisatrio.apps.kotlin.journal3.story.cache
 import com.hadisatrio.apps.kotlin.journal3.story.Story
 import com.hadisatrio.libs.kotlin.foundation.presentation.Presenter
 
+/**
+ * A [Presenter] decorator that wraps the presented [Story] in a [CachingStory]
+ * before forwarding to the underlying presenter.
+ */
 class CachingStoryPresenter(
     private val origin: Presenter<Story>
 ) : Presenter<Story> {

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/Token.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/Token.kt
@@ -17,6 +17,13 @@
 
 package com.hadisatrio.apps.kotlin.journal3.token
 
+/**
+ * A single-word tag prefixed with '@' (person) or '#' (topic), extractable
+ * from free-form journal text.
+ *
+ * @throws IllegalArgumentException if [raw] is blank, contains spaces, or does
+ *   not start with a recognised prefix character ('@' or '#').
+ */
 class Token(raw: String) {
 
     private val value: String = raw

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/TokenAnalyst.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/TokenAnalyst.kt
@@ -17,6 +17,13 @@
 
 package com.hadisatrio.apps.kotlin.journal3.token
 
+/**
+ * An analyst that extracts [Token]s from free-form text.
+ */
 fun interface TokenAnalyst {
+
+    /**
+     * Returns all [Token]s found in [string].
+     */
     fun analyze(string: String): Set<Token>
 }

--- a/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/TokenableString.kt
+++ b/app-kmm-journal3/src/commonMain/kotlin/com/hadisatrio/apps/kotlin/journal3/token/TokenableString.kt
@@ -19,11 +19,17 @@ package com.hadisatrio.apps.kotlin.journal3.token
 
 import kotlin.jvm.JvmInline
 
+/**
+ * A string wrapper that can parse embedded [Token]s from its content.
+ */
 @JvmInline
 value class TokenableString(
     private val value: String
 ) {
 
+    /**
+     * Returns all [Token]s embedded in this string, identified by '@' or '#' prefixes.
+     */
     fun tokens(): Set<Token> {
         return Regex("(?<=\\s|^)([#|@][\\w_-]+)")
             .findAll(value)


### PR DESCRIPTION
## What has changed?

Added KDoc documentation to all public classes, interfaces, functions, and properties under the `:app-kmm-journal3` module.

This is a continuation of #342.

## Why it was changed?

Comprehensive API documentation improves developer experience by:
- Making the purpose and usage of each public API immediately clear
- Reducing the need to read implementation code to understand behavior
- Enabling IDE tooltips and autocomplete hints
- Facilitating better code navigation and discoverability
- Establishing a foundation for generated API documentation

This is a documentation-only change with no impact on runtime behavior or functionality.